### PR TITLE
rewrite classifier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Test
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
+  test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,3 +36,6 @@ jobs:
 
       - name: Run mypy
         run: make mypy
+
+      - name: Run pytest
+        run: make pytest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.PHONY: lint
-lint: flake8 mypy
+.PHONY: test
+test: flake8 mypy pytest
 
 .PHONY: flake8
 flake8:
@@ -8,6 +8,10 @@ flake8:
 .PHONY: mypy
 mypy:
 	@poetry run mypy .
+
+.PHONY: pytest
+pytest:
+	@poetry run python -m pytest -svx
 
 .PHONY: access.token
 access.token:

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -6,7 +6,7 @@ import operator
 from collections import defaultdict
 from pathlib import Path
 from re import Pattern
-from typing import Literal, Optional, cast
+from typing import Literal, Mapping, Optional, cast
 
 from pydantic import BaseModel, ConfigDict, RootModel
 
@@ -24,9 +24,11 @@ class RulePatternIndex(
 
     def __init__(
         self,
-        root: Optional[dict[tuple[Action, StreamId, EntryAttr], PatternTexts]] = None,
+        root: Optional[
+            Mapping[tuple[Action, StreamId, EntryAttr], PatternTexts]
+        ] = None,
     ) -> None:
-        super().__init__(root=root or {})
+        super().__init__(root=dict(root or {}))
 
     def __or__(self, other: RulePatternIndex) -> RulePatternIndex:
         merged_root: defaultdict[tuple[Action, StreamId, EntryAttr], PatternTexts] = (

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -32,14 +32,14 @@ class RulePatternIndex(
 
     def __or__(self, other: RulePatternIndex) -> RulePatternIndex:
         merged_root: defaultdict[tuple[Action, StreamId, EntryAttr], PatternTexts] = (
-            defaultdict(lambda: PatternTexts(frozenset()))
+            defaultdict(PatternTexts)
         )
 
         for root in [self.root, other.root]:
-            for key, pattern_text_set in root.items():
-                merged_root[key] |= pattern_text_set
+            for key, pattern_texts in root.items():
+                merged_root[key] |= pattern_texts
 
-        return RulePatternIndex.model_validate(merged_root)
+        return RulePatternIndex(merged_root)
 
     @classmethod
     def from_rule(cls, rule: Rule) -> RulePatternIndex:

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -58,7 +58,9 @@ class RulePatternIndex(
 
     @classmethod
     def from_rules(cls, rules: Rules) -> RulePatternIndex:
-        return functools.reduce(operator.__or__, rules)
+        return functools.reduce(
+            operator.__or__, [cls.from_rule(rule) for rule in rules]
+        )
 
 
 class Classifier(BaseModel):

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -52,7 +52,7 @@ class RulePatternIndex(
                 (action, stream_id, cast(EntryAttr, entry_attr)): pattern_text_set
                 for action in rule.actions
                 for stream_id in rule.stream_ids
-                for entry_attr, pattern_text_set in rule.patterns
+                for entry_attr, pattern_text_set in rule.patterns.model_dump().items()
             }
         )
 

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -22,6 +22,12 @@ class RulePatternIndex(
 ):
     model_config = ConfigDict(frozen=True)
 
+    def __init__(
+        self,
+        root: Optional[dict[tuple[Action, StreamId, EntryAttr], PatternTexts]] = None,
+    ) -> None:
+        super().__init__(root=root or {})
+
     def __or__(self, other: RulePatternIndex) -> RulePatternIndex:
         merged_root: defaultdict[tuple[Action, StreamId, EntryAttr], PatternTexts] = (
             defaultdict(lambda: PatternTexts(frozenset()))
@@ -84,7 +90,7 @@ class Classifier(BaseModel):
                     RulePatternIndex.from_rules(Rules.from_yaml(p))
                     for p in yaml_file_paths
                 ),
-                RulePatternIndex(root={}),
+                RulePatternIndex(),
             )
         )
 

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -20,9 +20,6 @@ EntryAttr = Literal["title", "content"]
 class PatternTexts(RootModel[frozenset[PatternText]]):
     model_config = ConfigDict(frozen=True)
 
-    def __bool__(self) -> bool:
-        return bool(self.root)
-
     def __or__(self, other: PatternTexts) -> PatternTexts:
         return PatternTexts.model_validate(self.root | other.root)
 
@@ -81,7 +78,7 @@ class Classifier(BaseModel):
     ) -> Classifier:
         return cls(
             compiled_rule_index={
-                key: pattern_texts.compile() if pattern_texts else None
+                key: pattern_texts.compile()
                 for key, pattern_texts in rule_pattern_index.root.items()
             }
         )

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -23,7 +23,7 @@ class PatternTexts(RootModel[frozenset[PatternText]]):
     def __or__(self, other: PatternTexts) -> PatternTexts:
         return PatternTexts.model_validate(self.root | other.root)
 
-    def compile(self) -> Optional[Pattern[PatternText]]:
+    def compile(self) -> Optional[Pattern]:
         if not self.root:
             return None
         return re.compile("|".join(self.root))
@@ -68,9 +68,7 @@ class RulePatternIndex(
 class Classifier(BaseModel):
     model_config = ConfigDict(frozen=True)
 
-    compiled_rule_index: dict[
-        tuple[Action, StreamId, EntryAttr], Optional[Pattern[PatternText]]
-    ]
+    compiled_rule_index: dict[tuple[Action, StreamId, EntryAttr], Optional[Pattern]]
 
     @classmethod
     def from_rule_pattern_index(

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -20,6 +20,9 @@ EntryAttr = Literal["title", "content"]
 class PatternTexts(RootModel[frozenset[PatternText]]):
     model_config = ConfigDict(frozen=True)
 
+    def __bool__(self) -> bool:
+        return bool(self.root)
+
     def __or__(self, other: PatternTexts) -> PatternTexts:
         return PatternTexts.model_validate(self.root | other.root)
 

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -62,7 +62,9 @@ class RulePatternIndex(
     @classmethod
     def from_rules(cls, rules: Rules) -> RulePatternIndex:
         return functools.reduce(
-            operator.__or__, [cls.from_rule(rule) for rule in rules]
+            operator.__or__,
+            (cls.from_rule(rule) for rule in rules),
+            cls(root={}),
         )
 
 

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import itertools
 import operator
-import re
 from collections import defaultdict
 from pathlib import Path
 from re import Pattern
@@ -12,21 +11,10 @@ from typing import Literal, Optional, cast
 from pydantic import BaseModel, ConfigDict, RootModel
 
 from feedly_regexp_marker.feedly_controller import Action, Entry, StreamId
-from feedly_regexp_marker.rules import PatternText, Rule, Rules
+from feedly_regexp_marker.pattern_texts import PatternTexts
+from feedly_regexp_marker.rules import Rule, Rules
 
 EntryAttr = Literal["title", "content"]
-
-
-class PatternTexts(RootModel[frozenset[PatternText]]):
-    model_config = ConfigDict(frozen=True)
-
-    def __or__(self, other: PatternTexts) -> PatternTexts:
-        return PatternTexts.model_validate(self.root | other.root)
-
-    def compile(self) -> Optional[Pattern]:
-        if not self.root:
-            return None
-        return re.compile("|".join(self.root))
 
 
 class RulePatternIndex(

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -98,6 +98,7 @@ class Classifier(BaseModel):
                             yml_path.glob("*.yaml"), yml_path.glob("*.yml")
                         )
                     ],
+                    RulePatternIndex(root={}),
                 )
             )
         else:

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -85,23 +85,22 @@ class Classifier(BaseModel):
 
     @classmethod
     def from_yml(cls, yml_path: Path) -> Classifier:
-        if yml_path.is_dir():
-            return cls.from_rule_pattern_index(
-                functools.reduce(
-                    operator.__or__,
-                    [
-                        RulePatternIndex.from_rules(Rules.from_yaml(p))
-                        for p in itertools.chain(
-                            yml_path.glob("*.yaml"), yml_path.glob("*.yml")
-                        )
-                    ],
-                    RulePatternIndex(root={}),
-                )
+        yaml_file_paths = (
+            itertools.chain(yml_path.glob("*.yaml"), yml_path.glob("*.yml"))
+            if yml_path.is_dir()
+            else [yml_path]
+        )
+
+        return cls.from_rule_pattern_index(
+            functools.reduce(
+                operator.__or__,
+                (
+                    RulePatternIndex.from_rules(Rules.from_yaml(p))
+                    for p in yaml_file_paths
+                ),
+                RulePatternIndex(root={}),
             )
-        else:
-            return cls.from_rule_pattern_index(
-                RulePatternIndex.from_rules(Rules.from_yaml(yml_path))
-            )
+        )
 
     def __to_act(self, entry: Entry, action: Action) -> bool:
         if not entry.origin:

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -96,7 +96,7 @@ class Classifier(BaseModel):
             )
         )
 
-    def __to_act(self, entry: Entry, action: Action) -> bool:
+    def to_act(self, entry: Entry, action: Action) -> bool:
         if not entry.origin:
             return False
 
@@ -123,7 +123,7 @@ class Classifier(BaseModel):
         return False
 
     def to_save(self, entry: Entry) -> bool:
-        return self.__to_act(entry=entry, action="markAsSaved")
+        return self.to_act(entry=entry, action="markAsSaved")
 
     def to_read(self, entry: Entry) -> bool:
-        return self.__to_act(entry=entry, action="markAsRead")
+        return self.to_act(entry=entry, action="markAsRead")

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -27,7 +27,6 @@ class PatternTexts(RootModel[frozenset[PatternText]]):
         return re.compile("|".join(self.root))
 
 
-RulesDictRoot = dict[tuple[Action, StreamId, EntryAttr], PatternTexts]
 CompiledRulesDict = dict[
     tuple[Action, StreamId, EntryAttr], Optional[Pattern[PatternText]]
 ]
@@ -45,7 +44,7 @@ def merge_rules_dict(*args: RulesDict) -> RulesDict:
     return RulesDict.model_validate(root)
 
 
-class RulesDict(RootModel[RulesDictRoot]):
+class RulesDict(RootModel[dict[tuple[Action, StreamId, EntryAttr], PatternTexts]]):
     @classmethod
     def from_rule(cls, rule: Rule) -> RulesDict:
         return cls(

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -32,6 +32,8 @@ class PatternTexts(RootModel[frozenset[PatternText]]):
 class RulePatternIndex(
     RootModel[dict[tuple[Action, StreamId, EntryAttr], PatternTexts]]
 ):
+    model_config = ConfigDict(frozen=True)
+
     def __or__(self, other: RulePatternIndex) -> RulePatternIndex:
         merged_root: defaultdict[tuple[Action, StreamId, EntryAttr], PatternTexts] = (
             defaultdict(lambda: PatternTexts(frozenset()))

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -106,33 +106,25 @@ class Classifier(BaseModel):
         if not entry.origin:
             return False
 
-        try:
-            title_pattern = self.compiled_rule_index[
-                (action, entry.origin.streamId, "title")
-            ]
-        except KeyError:
-            pass
-        else:
-            if entry.title and title_pattern and title_pattern.search(entry.title):
-                return True
+        title_pattern = self.compiled_rule_index.get(
+            (action, entry.origin.streamId, "title")
+        )
+        if entry.title and title_pattern and title_pattern.search(entry.title):
+            return True
 
-        try:
-            content_pattern = self.compiled_rule_index[
-                (action, entry.origin.streamId, "content")
-            ]
-        except KeyError:
-            pass
-        else:
-            if (
-                entry.content
-                and content_pattern
-                and content_pattern.search(entry.content.content)
-            ) or (
-                entry.summary
-                and content_pattern
-                and content_pattern.search(entry.summary.content)
-            ):
-                return True
+        content_pattern = self.compiled_rule_index.get(
+            (action, entry.origin.streamId, "content")
+        )
+        if (
+            entry.content
+            and content_pattern
+            and content_pattern.search(entry.content.content)
+        ) or (
+            entry.summary
+            and content_pattern
+            and content_pattern.search(entry.summary.content)
+        ):
+            return True
 
         return False
 

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -64,6 +64,8 @@ class RulePatternIndex(
 
 
 class Classifier(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     compiled_rule_index: dict[
         tuple[Action, StreamId, EntryAttr], Optional[Pattern[PatternText]]
     ]

--- a/feedly_regexp_marker/feedly_controller.py
+++ b/feedly_regexp_marker/feedly_controller.py
@@ -19,7 +19,7 @@ class EntryContent(BaseModel):
 
 class EntryOrigin(BaseModel):
     streamId: StreamId
-    title: Optional[str]
+    title: Optional[str] = None
 
     class Config:
         frozen = True

--- a/feedly_regexp_marker/pattern_texts.py
+++ b/feedly_regexp_marker/pattern_texts.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import re
+from re import Pattern
+from typing import Annotated, Optional
+
+from pydantic import ConfigDict, RootModel, StringConstraints
+
+PatternText = Annotated[str, StringConstraints(min_length=1)]
+
+
+class PatternTexts(RootModel[frozenset[PatternText]]):
+    model_config = ConfigDict(frozen=True)
+
+    def __init__(self, root: frozenset[PatternText] = frozenset()) -> None:
+        super().__init__(root=root)
+
+    def __or__(self, other: PatternTexts) -> PatternTexts:
+        return PatternTexts.model_validate(self.root | other.root)
+
+    def compile(self) -> Optional[Pattern]:
+        if not self.root:
+            return None
+        return re.compile("|".join(self.root))

--- a/feedly_regexp_marker/pattern_texts.py
+++ b/feedly_regexp_marker/pattern_texts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from re import Pattern
-from typing import Annotated, Optional
+from typing import Annotated, Iterable, Optional
 
 from pydantic import ConfigDict, RootModel, StringConstraints
 
@@ -12,8 +12,8 @@ PatternText = Annotated[str, StringConstraints(min_length=1)]
 class PatternTexts(RootModel[frozenset[PatternText]]):
     model_config = ConfigDict(frozen=True)
 
-    def __init__(self, root: frozenset[PatternText] = frozenset()) -> None:
-        super().__init__(root=root)
+    def __init__(self, root: Iterable[PatternText] = frozenset()) -> None:
+        super().__init__(root=frozenset(root))
 
     def __or__(self, other: PatternTexts) -> PatternTexts:
         return PatternTexts.model_validate(self.root | other.root)

--- a/feedly_regexp_marker/rules.py
+++ b/feedly_regexp_marker/rules.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, RootModel
+from pydantic_yaml import parse_yaml_file_as
+
+from feedly_regexp_marker.feedly_controller import Action, StreamId
+
+PatternText = str
+
+
+class EntryPatternTexts(BaseModel):
+    title: frozenset[PatternText] = frozenset()
+    content: frozenset[PatternText] = frozenset()
+    model_config = ConfigDict(frozen=True)
+
+
+class Rule(BaseModel):
+    stream_ids: frozenset[StreamId]
+    actions: frozenset[Action]
+    patterns: EntryPatternTexts
+    name: Optional[str] = None
+    model_config = ConfigDict(frozen=True)
+
+
+class Rules(RootModel[frozenset[Rule]]):
+    model_config = ConfigDict(frozen=True)
+
+    def __iter__(self):
+        yield from self.root.__iter__()
+
+    @classmethod
+    def from_yaml(cls, yaml_path: Path) -> Rules:
+        return parse_yaml_file_as(cls, yaml_path)

--- a/feedly_regexp_marker/rules.py
+++ b/feedly_regexp_marker/rules.py
@@ -30,6 +30,9 @@ class Rules(RootModel[frozenset[Rule]]):
     def __iter__(self):
         yield from self.root.__iter__()
 
+    def __or__(self, other: Rules) -> Rules:
+        return Rules(root=self.root | other.root)
+
     @classmethod
     def from_yaml(cls, yaml_path: Path) -> Rules:
         return parse_yaml_file_as(cls, yaml_path)

--- a/feedly_regexp_marker/rules.py
+++ b/feedly_regexp_marker/rules.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, RootModel, StringConstraints
+from pydantic import BaseModel, ConfigDict, RootModel
 from pydantic_yaml import parse_yaml_file_as
 
 from feedly_regexp_marker.feedly_controller import Action, StreamId
-
-PatternText = Annotated[str, StringConstraints(min_length=1)]
+from feedly_regexp_marker.pattern_texts import PatternTexts
 
 
 class EntryPatternTexts(BaseModel):
-    title: frozenset[PatternText] = frozenset()
-    content: frozenset[PatternText] = frozenset()
+    title: PatternTexts = PatternTexts()
+    content: PatternTexts = PatternTexts()
     model_config = ConfigDict(frozen=True)
 
 

--- a/feedly_regexp_marker/rules.py
+++ b/feedly_regexp_marker/rules.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Annotated, Optional
 
-from pydantic import BaseModel, ConfigDict, RootModel
+from pydantic import BaseModel, ConfigDict, RootModel, StringConstraints
 from pydantic_yaml import parse_yaml_file_as
 
 from feedly_regexp_marker.feedly_controller import Action, StreamId
 
-PatternText = str
+PatternText = Annotated[str, StringConstraints(min_length=1)]
 
 
 class EntryPatternTexts(BaseModel):

--- a/poetry.lock
+++ b/poetry.lock
@@ -370,6 +370,20 @@ wrapt = ">=1.10,<2"
 dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "setuptools", "tox"]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.2.2"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "feedly-client"
 version = "0.23.2"
 description = "A lightweight client for the feedly api (https://developers.feedly.com)."
@@ -514,6 +528,17 @@ files = [
 
 [package.extras]
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+]
 
 [[package]]
 name = "isort"
@@ -797,6 +822,21 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-
 type = ["mypy (>=1.11.2)"]
 
 [[package]]
+name = "pluggy"
+version = "1.5.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "propcache"
 version = "0.2.1"
 description = "Accelerated property cache"
@@ -1029,6 +1069,28 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.5,<2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "requests"
@@ -1460,4 +1522,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "573934f7a32a74844879877f4f16f329d5c803350e2ce720e992b2515ed2b564"
+content-hash = "3ba0239d0fb80bfe4e1bdde885559f17cd56d56e051e58342ddd650aedb7bdee"

--- a/poetry.lock
+++ b/poetry.lock
@@ -129,6 +129,17 @@ files = [
 frozenlist = ">=1.1.0"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+description = "Reusable constraint types to use with typing.Annotated"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
+    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 description = "Timeout context manager for asyncio programs"
@@ -351,23 +362,6 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-
-[[package]]
-name = "deprecated"
-version = "1.2.18"
-description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-files = [
-    {file = "Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec"},
-    {file = "deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d"},
-]
-
-[package.dependencies]
-wrapt = ">=1.10,<2"
-
-[package.extras]
-dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "setuptools", "tox"]
 
 [[package]]
 name = "exceptiongroup"
@@ -940,93 +934,155 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "1.10.21"
-description = "Data validation and settings management using python type hints"
+version = "2.11.3"
+description = "Data validation using Python type hints"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 files = [
-    {file = "pydantic-1.10.21-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:245e486e0fec53ec2366df9cf1cba36e0bbf066af7cd9c974bbbd9ba10e1e586"},
-    {file = "pydantic-1.10.21-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6c54f8d4c151c1de784c5b93dfbb872067e3414619e10e21e695f7bb84d1d1fd"},
-    {file = "pydantic-1.10.21-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b64708009cfabd9c2211295144ff455ec7ceb4c4fb45a07a804309598f36187"},
-    {file = "pydantic-1.10.21-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a148410fa0e971ba333358d11a6dea7b48e063de127c2b09ece9d1c1137dde4"},
-    {file = "pydantic-1.10.21-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:36ceadef055af06e7756eb4b871cdc9e5a27bdc06a45c820cd94b443de019bbf"},
-    {file = "pydantic-1.10.21-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c0501e1d12df6ab1211b8cad52d2f7b2cd81f8e8e776d39aa5e71e2998d0379f"},
-    {file = "pydantic-1.10.21-cp310-cp310-win_amd64.whl", hash = "sha256:c261127c275d7bce50b26b26c7d8427dcb5c4803e840e913f8d9df3f99dca55f"},
-    {file = "pydantic-1.10.21-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8b6350b68566bb6b164fb06a3772e878887f3c857c46c0c534788081cb48adf4"},
-    {file = "pydantic-1.10.21-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:935b19fdcde236f4fbf691959fa5c3e2b6951fff132964e869e57c70f2ad1ba3"},
-    {file = "pydantic-1.10.21-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b6a04efdcd25486b27f24c1648d5adc1633ad8b4506d0e96e5367f075ed2e0b"},
-    {file = "pydantic-1.10.21-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c1ba253eb5af8d89864073e6ce8e6c8dec5f49920cff61f38f5c3383e38b1c9f"},
-    {file = "pydantic-1.10.21-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:57f0101e6c97b411f287a0b7cf5ebc4e5d3b18254bf926f45a11615d29475793"},
-    {file = "pydantic-1.10.21-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e85834f0370d737c77a386ce505c21b06bfe7086c1c568b70e15a568d9670d"},
-    {file = "pydantic-1.10.21-cp311-cp311-win_amd64.whl", hash = "sha256:6a497bc66b3374b7d105763d1d3de76d949287bf28969bff4656206ab8a53aa9"},
-    {file = "pydantic-1.10.21-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ed4a5f13cf160d64aa331ab9017af81f3481cd9fd0e49f1d707b57fe1b9f3ae"},
-    {file = "pydantic-1.10.21-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3b7693bb6ed3fbe250e222f9415abb73111bb09b73ab90d2d4d53f6390e0ccc1"},
-    {file = "pydantic-1.10.21-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:185d5f1dff1fead51766da9b2de4f3dc3b8fca39e59383c273f34a6ae254e3e2"},
-    {file = "pydantic-1.10.21-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:38e6d35cf7cd1727822c79e324fa0677e1a08c88a34f56695101f5ad4d5e20e5"},
-    {file = "pydantic-1.10.21-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:1d7c332685eafacb64a1a7645b409a166eb7537f23142d26895746f628a3149b"},
-    {file = "pydantic-1.10.21-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c9b782db6f993a36092480eeaab8ba0609f786041b01f39c7c52252bda6d85f"},
-    {file = "pydantic-1.10.21-cp312-cp312-win_amd64.whl", hash = "sha256:7ce64d23d4e71d9698492479505674c5c5b92cda02b07c91dfc13633b2eef805"},
-    {file = "pydantic-1.10.21-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0067935d35044950be781933ab91b9a708eaff124bf860fa2f70aeb1c4be7212"},
-    {file = "pydantic-1.10.21-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5e8148c2ce4894ce7e5a4925d9d3fdce429fb0e821b5a8783573f3611933a251"},
-    {file = "pydantic-1.10.21-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4973232c98b9b44c78b1233693e5e1938add5af18042f031737e1214455f9b8"},
-    {file = "pydantic-1.10.21-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:662bf5ce3c9b1cef32a32a2f4debe00d2f4839fefbebe1d6956e681122a9c839"},
-    {file = "pydantic-1.10.21-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:98737c3ab5a2f8a85f2326eebcd214510f898881a290a7939a45ec294743c875"},
-    {file = "pydantic-1.10.21-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0bb58bbe65a43483d49f66b6c8474424d551a3fbe8a7796c42da314bac712738"},
-    {file = "pydantic-1.10.21-cp313-cp313-win_amd64.whl", hash = "sha256:e622314542fb48542c09c7bd1ac51d71c5632dd3c92dc82ede6da233f55f4848"},
-    {file = "pydantic-1.10.21-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d356aa5b18ef5a24d8081f5c5beb67c0a2a6ff2a953ee38d65a2aa96526b274f"},
-    {file = "pydantic-1.10.21-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08caa8c0468172d27c669abfe9e7d96a8b1655ec0833753e117061febaaadef5"},
-    {file = "pydantic-1.10.21-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c677aa39ec737fec932feb68e4a2abe142682f2885558402602cd9746a1c92e8"},
-    {file = "pydantic-1.10.21-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:79577cc045d3442c4e845df53df9f9202546e2ba54954c057d253fc17cd16cb1"},
-    {file = "pydantic-1.10.21-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:b6b73ab347284719f818acb14f7cd80696c6fdf1bd34feee1955d7a72d2e64ce"},
-    {file = "pydantic-1.10.21-cp37-cp37m-win_amd64.whl", hash = "sha256:46cffa24891b06269e12f7e1ec50b73f0c9ab4ce71c2caa4ccf1fb36845e1ff7"},
-    {file = "pydantic-1.10.21-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:298d6f765e3c9825dfa78f24c1efd29af91c3ab1b763e1fd26ae4d9e1749e5c8"},
-    {file = "pydantic-1.10.21-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f2f4a2305f15eff68f874766d982114ac89468f1c2c0b97640e719cf1a078374"},
-    {file = "pydantic-1.10.21-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:35b263b60c519354afb3a60107d20470dd5250b3ce54c08753f6975c406d949b"},
-    {file = "pydantic-1.10.21-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e23a97a6c2f2db88995496db9387cd1727acdacc85835ba8619dce826c0b11a6"},
-    {file = "pydantic-1.10.21-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:3c96fed246ccc1acb2df032ff642459e4ae18b315ecbab4d95c95cfa292e8517"},
-    {file = "pydantic-1.10.21-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:b92893ebefc0151474f682e7debb6ab38552ce56a90e39a8834734c81f37c8a9"},
-    {file = "pydantic-1.10.21-cp38-cp38-win_amd64.whl", hash = "sha256:b8460bc256bf0de821839aea6794bb38a4c0fbd48f949ea51093f6edce0be459"},
-    {file = "pydantic-1.10.21-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5d387940f0f1a0adb3c44481aa379122d06df8486cc8f652a7b3b0caf08435f7"},
-    {file = "pydantic-1.10.21-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:266ecfc384861d7b0b9c214788ddff75a2ea123aa756bcca6b2a1175edeca0fe"},
-    {file = "pydantic-1.10.21-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61da798c05a06a362a2f8c5e3ff0341743e2818d0f530eaac0d6898f1b187f1f"},
-    {file = "pydantic-1.10.21-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a621742da75ce272d64ea57bd7651ee2a115fa67c0f11d66d9dcfc18c2f1b106"},
-    {file = "pydantic-1.10.21-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:9e3e4000cd54ef455694b8be9111ea20f66a686fc155feda1ecacf2322b115da"},
-    {file = "pydantic-1.10.21-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f198c8206640f4c0ef5a76b779241efb1380a300d88b1bce9bfe95a6362e674d"},
-    {file = "pydantic-1.10.21-cp39-cp39-win_amd64.whl", hash = "sha256:e7f0cda108b36a30c8fc882e4fc5b7eec8ef584aa43aa43694c6a7b274fb2b56"},
-    {file = "pydantic-1.10.21-py3-none-any.whl", hash = "sha256:db70c920cba9d05c69ad4a9e7f8e9e83011abb2c6490e561de9ae24aee44925c"},
-    {file = "pydantic-1.10.21.tar.gz", hash = "sha256:64b48e2b609a6c22178a56c408ee1215a7206077ecb8a193e2fda31858b2362a"},
+    {file = "pydantic-2.11.3-py3-none-any.whl", hash = "sha256:a082753436a07f9ba1289c6ffa01cd93db3548776088aa917cc43b63f68fa60f"},
+    {file = "pydantic-2.11.3.tar.gz", hash = "sha256:7471657138c16adad9322fe3070c0116dd6c3ad8d649300e3cbdfe91f4db4ec3"},
 ]
 
 [package.dependencies]
-typing-extensions = ">=4.2.0"
+annotated-types = ">=0.6.0"
+pydantic-core = "2.33.1"
+typing-extensions = ">=4.12.2"
+typing-inspection = ">=0.4.0"
 
 [package.extras]
-dotenv = ["python-dotenv (>=0.10.4)"]
-email = ["email-validator (>=1.0.3)"]
+email = ["email-validator (>=2.0.0)"]
+timezone = ["tzdata"]
+
+[[package]]
+name = "pydantic-core"
+version = "2.33.1"
+description = "Core functionality for Pydantic validation and serialization"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pydantic_core-2.33.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3077cfdb6125cc8dab61b155fdd714663e401f0e6883f9632118ec12cf42df26"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8ffab8b2908d152e74862d276cf5017c81a2f3719f14e8e3e8d6b83fda863927"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5183e4f6a2d468787243ebcd70cf4098c247e60d73fb7d68d5bc1e1beaa0c4db"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:398a38d323f37714023be1e0285765f0a27243a8b1506b7b7de87b647b517e48"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:87d3776f0001b43acebfa86f8c64019c043b55cc5a6a2e313d728b5c95b46969"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c566dd9c5f63d22226409553531f89de0cac55397f2ab8d97d6f06cfce6d947e"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0d5f3acc81452c56895e90643a625302bd6be351e7010664151cc55b7b97f89"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d3a07fadec2a13274a8d861d3d37c61e97a816beae717efccaa4b36dfcaadcde"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f99aeda58dce827f76963ee87a0ebe75e648c72ff9ba1174a253f6744f518f65"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:902dbc832141aa0ec374f4310f1e4e7febeebc3256f00dc359a9ac3f264a45dc"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fe44d56aa0b00d66640aa84a3cbe80b7a3ccdc6f0b1ca71090696a6d4777c091"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-win32.whl", hash = "sha256:ed3eb16d51257c763539bde21e011092f127a2202692afaeaccb50db55a31383"},
+    {file = "pydantic_core-2.33.1-cp310-cp310-win_amd64.whl", hash = "sha256:694ad99a7f6718c1a498dc170ca430687a39894a60327f548e02a9c7ee4b6504"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6e966fc3caaf9f1d96b349b0341c70c8d6573bf1bac7261f7b0ba88f96c56c24"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bfd0adeee563d59c598ceabddf2c92eec77abcb3f4a391b19aa7366170bd9e30"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91815221101ad3c6b507804178a7bb5cb7b2ead9ecd600041669c8d805ebd595"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9fea9c1869bb4742d174a57b4700c6dadea951df8b06de40c2fedb4f02931c2e"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d20eb4861329bb2484c021b9d9a977566ab16d84000a57e28061151c62b349a"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb935c5591573ae3201640579f30128ccc10739b45663f93c06796854405505"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c964fd24e6166420d18fb53996d8c9fd6eac9bf5ae3ec3d03015be4414ce497f"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:681d65e9011f7392db5aa002b7423cc442d6a673c635668c227c6c8d0e5a4f77"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e100c52f7355a48413e2999bfb4e139d2977a904495441b374f3d4fb4a170961"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:048831bd363490be79acdd3232f74a0e9951b11b2b4cc058aeb72b22fdc3abe1"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bdc84017d28459c00db6f918a7272a5190bec3090058334e43a76afb279eac7c"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-win32.whl", hash = "sha256:32cd11c5914d1179df70406427097c7dcde19fddf1418c787540f4b730289896"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-win_amd64.whl", hash = "sha256:2ea62419ba8c397e7da28a9170a16219d310d2cf4970dbc65c32faf20d828c83"},
+    {file = "pydantic_core-2.33.1-cp311-cp311-win_arm64.whl", hash = "sha256:fc903512177361e868bc1f5b80ac8c8a6e05fcdd574a5fb5ffeac5a9982b9e89"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:1293d7febb995e9d3ec3ea09caf1a26214eec45b0f29f6074abb004723fc1de8"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:99b56acd433386c8f20be5c4000786d1e7ca0523c8eefc995d14d79c7a081498"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35a5ec3fa8c2fe6c53e1b2ccc2454398f95d5393ab398478f53e1afbbeb4d939"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b172f7b9d2f3abc0efd12e3386f7e48b576ef309544ac3a63e5e9cdd2e24585d"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9097b9f17f91eea659b9ec58148c0747ec354a42f7389b9d50701610d86f812e"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc77ec5b7e2118b152b0d886c7514a4653bcb58c6b1d760134a9fab915f777b3"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5e3d15245b08fa4a84cefc6c9222e6f37c98111c8679fbd94aa145f9a0ae23d"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ef99779001d7ac2e2461d8ab55d3373fe7315caefdbecd8ced75304ae5a6fc6b"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:fc6bf8869e193855e8d91d91f6bf59699a5cdfaa47a404e278e776dd7f168b39"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:b1caa0bc2741b043db7823843e1bde8aaa58a55a58fda06083b0569f8b45693a"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ec259f62538e8bf364903a7d0d0239447059f9434b284f5536e8402b7dd198db"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-win32.whl", hash = "sha256:e14f369c98a7c15772b9da98987f58e2b509a93235582838bd0d1d8c08b68fda"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-win_amd64.whl", hash = "sha256:1c607801d85e2e123357b3893f82c97a42856192997b95b4d8325deb1cd0c5f4"},
+    {file = "pydantic_core-2.33.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d13f0276806ee722e70a1c93da19748594f19ac4299c7e41237fc791d1861ea"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:70af6a21237b53d1fe7b9325b20e65cbf2f0a848cf77bed492b029139701e66a"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:282b3fe1bbbe5ae35224a0dbd05aed9ccabccd241e8e6b60370484234b456266"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b315e596282bbb5822d0c7ee9d255595bd7506d1cb20c2911a4da0b970187d3"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1dfae24cf9921875ca0ca6a8ecb4bb2f13c855794ed0d468d6abbec6e6dcd44a"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6dd8ecfde08d8bfadaea669e83c63939af76f4cf5538a72597016edfa3fad516"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2f593494876eae852dc98c43c6f260f45abdbfeec9e4324e31a481d948214764"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:948b73114f47fd7016088e5186d13faf5e1b2fe83f5e320e371f035557fd264d"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e11f3864eb516af21b01e25fac915a82e9ddad3bb0fb9e95a246067398b435a4"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:549150be302428b56fdad0c23c2741dcdb5572413776826c965619a25d9c6bde"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:495bc156026efafd9ef2d82372bd38afce78ddd82bf28ef5276c469e57c0c83e"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ec79de2a8680b1a67a07490bddf9636d5c2fab609ba8c57597e855fa5fa4dacd"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-win32.whl", hash = "sha256:ee12a7be1742f81b8a65b36c6921022301d466b82d80315d215c4c691724986f"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-win_amd64.whl", hash = "sha256:ede9b407e39949d2afc46385ce6bd6e11588660c26f80576c11c958e6647bc40"},
+    {file = "pydantic_core-2.33.1-cp313-cp313-win_arm64.whl", hash = "sha256:aa687a23d4b7871a00e03ca96a09cad0f28f443690d300500603bd0adba4b523"},
+    {file = "pydantic_core-2.33.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:401d7b76e1000d0dd5538e6381d28febdcacb097c8d340dde7d7fc6e13e9f95d"},
+    {file = "pydantic_core-2.33.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7aeb055a42d734c0255c9e489ac67e75397d59c6fbe60d155851e9782f276a9c"},
+    {file = "pydantic_core-2.33.1-cp313-cp313t-win_amd64.whl", hash = "sha256:338ea9b73e6e109f15ab439e62cb3b78aa752c7fd9536794112e14bee02c8d18"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:5ab77f45d33d264de66e1884fca158bc920cb5e27fd0764a72f72f5756ae8bdb"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7aaba1b4b03aaea7bb59e1b5856d734be011d3e6d98f5bcaa98cb30f375f2ad"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fb66263e9ba8fea2aa85e1e5578980d127fb37d7f2e292773e7bc3a38fb0c7b"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3f2648b9262607a7fb41d782cc263b48032ff7a03a835581abbf7a3bec62bcf5"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:723c5630c4259400818b4ad096735a829074601805d07f8cafc366d95786d331"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d100e3ae783d2167782391e0c1c7a20a31f55f8015f3293647544df3f9c67824"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:177d50460bc976a0369920b6c744d927b0ecb8606fb56858ff542560251b19e5"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a3edde68d1a1f9af1273b2fe798997b33f90308fb6d44d8550c89fc6a3647cf6"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a62c3c3ef6a7e2c45f7853b10b5bc4ddefd6ee3cd31024754a1a5842da7d598d"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:c91dbb0ab683fa0cd64a6e81907c8ff41d6497c346890e26b23de7ee55353f96"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9f466e8bf0a62dc43e068c12166281c2eca72121dd2adc1040f3aa1e21ef8599"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-win32.whl", hash = "sha256:ab0277cedb698749caada82e5d099dc9fed3f906a30d4c382d1a21725777a1e5"},
+    {file = "pydantic_core-2.33.1-cp39-cp39-win_amd64.whl", hash = "sha256:5773da0ee2d17136b1f1c6fbde543398d452a6ad2a7b54ea1033e2daa739b8d2"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5c834f54f8f4640fd7e4b193f80eb25a0602bba9e19b3cd2fc7ffe8199f5ae02"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:049e0de24cf23766f12cc5cc71d8abc07d4a9deb9061b334b62093dedc7cb068"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a28239037b3d6f16916a4c831a5a0eadf856bdd6d2e92c10a0da3a59eadcf3e"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d3da303ab5f378a268fa7d45f37d7d85c3ec19769f28d2cc0c61826a8de21fe"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:25626fb37b3c543818c14821afe0fd3830bc327a43953bc88db924b68c5723f1"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3ab2d36e20fbfcce8f02d73c33a8a7362980cff717926bbae030b93ae46b56c7"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:2f9284e11c751b003fd4215ad92d325d92c9cb19ee6729ebd87e3250072cdcde"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:048c01eee07d37cbd066fc512b9d8b5ea88ceeb4e629ab94b3e56965ad655add"},
+    {file = "pydantic_core-2.33.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:5ccd429694cf26af7997595d627dd2637e7932214486f55b8a357edaac9dae8c"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3a371dc00282c4b84246509a5ddc808e61b9864aa1eae9ecc92bb1268b82db4a"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f59295ecc75a1788af8ba92f2e8c6eeaa5a94c22fc4d151e8d9638814f85c8fc"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08530b8ac922003033f399128505f513e30ca770527cc8bbacf75a84fcc2c74b"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae370459da6a5466978c0eacf90690cb57ec9d533f8e63e564ef3822bfa04fe"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e3de2777e3b9f4d603112f78006f4ae0acb936e95f06da6cb1a45fbad6bdb4b5"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3a64e81e8cba118e108d7126362ea30e021291b7805d47e4896e52c791be2761"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:52928d8c1b6bda03cc6d811e8923dffc87a2d3c8b3bfd2ce16471c7147a24850"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:1b30d92c9412beb5ac6b10a3eb7ef92ccb14e3f2a8d7732e2d739f58b3aa7544"},
+    {file = "pydantic_core-2.33.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f995719707e0e29f0f41a8aa3bcea6e761a36c9136104d3189eafb83f5cec5e5"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7edbc454a29fc6aeae1e1eecba4f07b63b8d76e76a748532233c4c167b4cb9ea"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:ad05b683963f69a1d5d2c2bdab1274a31221ca737dbbceaa32bcb67359453cdd"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df6a94bf9452c6da9b5d76ed229a5683d0306ccb91cca8e1eea883189780d568"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7965c13b3967909a09ecc91f21d09cfc4576bf78140b988904e94f130f188396"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3f1fdb790440a34f6ecf7679e1863b825cb5ffde858a9197f851168ed08371e5"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:5277aec8d879f8d05168fdd17ae811dd313b8ff894aeeaf7cd34ad28b4d77e33"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:8ab581d3530611897d863d1a649fb0644b860286b4718db919bfd51ece41f10b"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0483847fa9ad5e3412265c1bd72aad35235512d9ce9d27d81a56d935ef489672"},
+    {file = "pydantic_core-2.33.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:de9e06abe3cc5ec6a2d5f75bc99b0bdca4f5c719a5b34026f8c57efbdecd2ee3"},
+    {file = "pydantic_core-2.33.1.tar.gz", hash = "sha256:bcc9c6fdb0ced789245b02b7d6603e17d1563064ddcfc36f046b61c0c05dd9df"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pydantic-yaml"
-version = "0.6.3"
-description = "\"Adds some YAML functionality to the excellent `pydantic` library.\""
+version = "1.4.0"
+description = "Adds some YAML functionality to the excellent `pydantic` library."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pydantic_yaml-0.6.3-py3-none-any.whl", hash = "sha256:aaa3e9c55eeebc203dacd461ff635932d10a440bfda7f77f596351094c85322b"},
-    {file = "pydantic_yaml-0.6.3.tar.gz", hash = "sha256:8bec8b6eee9889073b5461075d8b85efb00ba43bd34d5fb331fa394ec5a3b46f"},
+    {file = "pydantic_yaml-1.4.0-py3-none-any.whl", hash = "sha256:f9ad82d8c0548e779e00d6ec639f6efa8f8c7e14d12d0bf9fdc400a37300d7ba"},
+    {file = "pydantic_yaml-1.4.0.tar.gz", hash = "sha256:09f6b9ec9d80550dd3a58596a6a0948a1830fae94b73329b95c2b9dbfc35ae00"},
 ]
 
 [package.dependencies]
-deprecated = ">=1.2.5,<1.3.0"
-pydantic = ">=1.7.4,<2.0"
-"ruamel.yaml" = {version = ">=0.15,<0.18", optional = true, markers = "extra == \"ruamel\""}
-semver = ">=2.13.0,<4"
-types-Deprecated = "*"
+pydantic = ">=1.8"
+"ruamel.yaml" = ">=0.16.0,<0.19.0"
+typing-extensions = ">=4.5.0"
 
 [package.extras]
-dev = ["black", "bump2version", "flake8", "mypy", "pytest"]
-docs = ["mkdocs", "mkdocs-material", "mkdocstrings", "pygments", "pymdown-extensions"]
-pyyaml = ["pyyaml", "types-PyYAML"]
-ruamel = ["ruamel.yaml (>=0.15,<0.18)"]
+dev = ["black (==24.8.0)", "mypy (==1.13.0)", "pre-commit (==3.5.0)", "pytest (==8.3.3)", "ruff (==0.7.3)", "setuptools (>=61.0.0)", "setuptools-scm[toml] (>=6.2)"]
+docs = ["mkdocs", "mkdocs-material", "mkdocstrings[python]", "pygments", "pymdown-extensions"]
 
 [[package]]
 name = "pydocstyle"
@@ -1134,13 +1190,13 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "ruamel-yaml"
-version = "0.17.40"
+version = "0.18.10"
 description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
 optional = false
-python-versions = ">=3"
+python-versions = ">=3.7"
 files = [
-    {file = "ruamel.yaml-0.17.40-py3-none-any.whl", hash = "sha256:b16b6c3816dff0a93dca12acf5e70afd089fa5acb80604afd1ffa8b465b7722c"},
-    {file = "ruamel.yaml-0.17.40.tar.gz", hash = "sha256:6024b986f06765d482b5b07e086cc4b4cd05dd22ddcbc758fa23d54873cf313d"},
+    {file = "ruamel.yaml-0.18.10-py3-none-any.whl", hash = "sha256:30f22513ab2301b3d2b577adc121c6471f28734d3d9728581245f1e76468b4f1"},
+    {file = "ruamel.yaml-0.18.10.tar.gz", hash = "sha256:20c86ab29ac2153f80a428e1254a8adf686d3383df04490514ca3b79a362db58"},
 ]
 
 [package.dependencies]
@@ -1203,17 +1259,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-win32.whl", hash = "sha256:beffaed67936fbbeffd10966a4eb53c402fafd3d6833770516bf7314bc6ffa12"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-win_amd64.whl", hash = "sha256:040ae85536960525ea62868b642bdb0c2cc6021c9f9d507810c0c604e66f5a7b"},
     {file = "ruamel.yaml.clib-0.2.12.tar.gz", hash = "sha256:6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f"},
-]
-
-[[package]]
-name = "semver"
-version = "3.0.4"
-description = "Python helper for Semantic Versioning (https://semver.org)"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746"},
-    {file = "semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602"},
 ]
 
 [[package]]
@@ -1297,17 +1342,6 @@ shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
 
 [[package]]
-name = "types-deprecated"
-version = "1.2.15.20241117"
-description = "Typing stubs for Deprecated"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "types-Deprecated-1.2.15.20241117.tar.gz", hash = "sha256:924002c8b7fddec51ba4949788a702411a2e3636cd9b2a33abd8ee119701d77e"},
-    {file = "types_Deprecated-1.2.15.20241117-py3-none-any.whl", hash = "sha256:a0cc5e39f769fc54089fd8e005416b55d74aa03f6964d2ed1a0b0b2e28751884"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -1317,6 +1351,20 @@ files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.0"
+description = "Runtime typing introspection tools"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f"},
+    {file = "typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "urllib3"
@@ -1334,94 +1382,6 @@ brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
-
-[[package]]
-name = "wrapt"
-version = "1.17.2"
-description = "Module for decorators, wrappers and monkey patching."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "wrapt-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d57c572081fed831ad2d26fd430d565b76aa277ed1d30ff4d40670b1c0dd984"},
-    {file = "wrapt-1.17.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b5e251054542ae57ac7f3fba5d10bfff615b6c2fb09abeb37d2f1463f841ae22"},
-    {file = "wrapt-1.17.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:80dd7db6a7cb57ffbc279c4394246414ec99537ae81ffd702443335a61dbf3a7"},
-    {file = "wrapt-1.17.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a6e821770cf99cc586d33833b2ff32faebdbe886bd6322395606cf55153246c"},
-    {file = "wrapt-1.17.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b60fb58b90c6d63779cb0c0c54eeb38941bae3ecf7a73c764c52c88c2dcb9d72"},
-    {file = "wrapt-1.17.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b870b5df5b71d8c3359d21be8f0d6c485fa0ebdb6477dda51a1ea54a9b558061"},
-    {file = "wrapt-1.17.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4011d137b9955791f9084749cba9a367c68d50ab8d11d64c50ba1688c9b457f2"},
-    {file = "wrapt-1.17.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:1473400e5b2733e58b396a04eb7f35f541e1fb976d0c0724d0223dd607e0f74c"},
-    {file = "wrapt-1.17.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3cedbfa9c940fdad3e6e941db7138e26ce8aad38ab5fe9dcfadfed9db7a54e62"},
-    {file = "wrapt-1.17.2-cp310-cp310-win32.whl", hash = "sha256:582530701bff1dec6779efa00c516496968edd851fba224fbd86e46cc6b73563"},
-    {file = "wrapt-1.17.2-cp310-cp310-win_amd64.whl", hash = "sha256:58705da316756681ad3c9c73fd15499aa4d8c69f9fd38dc8a35e06c12468582f"},
-    {file = "wrapt-1.17.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ff04ef6eec3eee8a5efef2401495967a916feaa353643defcc03fc74fe213b58"},
-    {file = "wrapt-1.17.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4db983e7bca53819efdbd64590ee96c9213894272c776966ca6306b73e4affda"},
-    {file = "wrapt-1.17.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9abc77a4ce4c6f2a3168ff34b1da9b0f311a8f1cfd694ec96b0603dff1c79438"},
-    {file = "wrapt-1.17.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b929ac182f5ace000d459c59c2c9c33047e20e935f8e39371fa6e3b85d56f4a"},
-    {file = "wrapt-1.17.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f09b286faeff3c750a879d336fb6d8713206fc97af3adc14def0cdd349df6000"},
-    {file = "wrapt-1.17.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a7ed2d9d039bd41e889f6fb9364554052ca21ce823580f6a07c4ec245c1f5d6"},
-    {file = "wrapt-1.17.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:129a150f5c445165ff941fc02ee27df65940fcb8a22a61828b1853c98763a64b"},
-    {file = "wrapt-1.17.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1fb5699e4464afe5c7e65fa51d4f99e0b2eadcc176e4aa33600a3df7801d6662"},
-    {file = "wrapt-1.17.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9a2bce789a5ea90e51a02dfcc39e31b7f1e662bc3317979aa7e5538e3a034f72"},
-    {file = "wrapt-1.17.2-cp311-cp311-win32.whl", hash = "sha256:4afd5814270fdf6380616b321fd31435a462019d834f83c8611a0ce7484c7317"},
-    {file = "wrapt-1.17.2-cp311-cp311-win_amd64.whl", hash = "sha256:acc130bc0375999da18e3d19e5a86403667ac0c4042a094fefb7eec8ebac7cf3"},
-    {file = "wrapt-1.17.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d5e2439eecc762cd85e7bd37161d4714aa03a33c5ba884e26c81559817ca0925"},
-    {file = "wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fc7cb4c1c744f8c05cd5f9438a3caa6ab94ce8344e952d7c45a8ed59dd88392"},
-    {file = "wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fdbdb757d5390f7c675e558fd3186d590973244fab0c5fe63d373ade3e99d40"},
-    {file = "wrapt-1.17.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bb1d0dbf99411f3d871deb6faa9aabb9d4e744d67dcaaa05399af89d847a91d"},
-    {file = "wrapt-1.17.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d18a4865f46b8579d44e4fe1e2bcbc6472ad83d98e22a26c963d46e4c125ef0b"},
-    {file = "wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc570b5f14a79734437cb7b0500376b6b791153314986074486e0b0fa8d71d98"},
-    {file = "wrapt-1.17.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6d9187b01bebc3875bac9b087948a2bccefe464a7d8f627cf6e48b1bbae30f82"},
-    {file = "wrapt-1.17.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9e8659775f1adf02eb1e6f109751268e493c73716ca5761f8acb695e52a756ae"},
-    {file = "wrapt-1.17.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e8b2816ebef96d83657b56306152a93909a83f23994f4b30ad4573b00bd11bb9"},
-    {file = "wrapt-1.17.2-cp312-cp312-win32.whl", hash = "sha256:468090021f391fe0056ad3e807e3d9034e0fd01adcd3bdfba977b6fdf4213ea9"},
-    {file = "wrapt-1.17.2-cp312-cp312-win_amd64.whl", hash = "sha256:ec89ed91f2fa8e3f52ae53cd3cf640d6feff92ba90d62236a81e4e563ac0e991"},
-    {file = "wrapt-1.17.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6ed6ffac43aecfe6d86ec5b74b06a5be33d5bb9243d055141e8cabb12aa08125"},
-    {file = "wrapt-1.17.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35621ae4c00e056adb0009f8e86e28eb4a41a4bfa8f9bfa9fca7d343fe94f998"},
-    {file = "wrapt-1.17.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a604bf7a053f8362d27eb9fefd2097f82600b856d5abe996d623babd067b1ab5"},
-    {file = "wrapt-1.17.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cbabee4f083b6b4cd282f5b817a867cf0b1028c54d445b7ec7cfe6505057cf8"},
-    {file = "wrapt-1.17.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49703ce2ddc220df165bd2962f8e03b84c89fee2d65e1c24a7defff6f988f4d6"},
-    {file = "wrapt-1.17.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8112e52c5822fc4253f3901b676c55ddf288614dc7011634e2719718eaa187dc"},
-    {file = "wrapt-1.17.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fee687dce376205d9a494e9c121e27183b2a3df18037f89d69bd7b35bcf59e2"},
-    {file = "wrapt-1.17.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:18983c537e04d11cf027fbb60a1e8dfd5190e2b60cc27bc0808e653e7b218d1b"},
-    {file = "wrapt-1.17.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:703919b1633412ab54bcf920ab388735832fdcb9f9a00ae49387f0fe67dad504"},
-    {file = "wrapt-1.17.2-cp313-cp313-win32.whl", hash = "sha256:abbb9e76177c35d4e8568e58650aa6926040d6a9f6f03435b7a522bf1c487f9a"},
-    {file = "wrapt-1.17.2-cp313-cp313-win_amd64.whl", hash = "sha256:69606d7bb691b50a4240ce6b22ebb319c1cfb164e5f6569835058196e0f3a845"},
-    {file = "wrapt-1.17.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4a721d3c943dae44f8e243b380cb645a709ba5bd35d3ad27bc2ed947e9c68192"},
-    {file = "wrapt-1.17.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:766d8bbefcb9e00c3ac3b000d9acc51f1b399513f44d77dfe0eb026ad7c9a19b"},
-    {file = "wrapt-1.17.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e496a8ce2c256da1eb98bd15803a79bee00fc351f5dfb9ea82594a3f058309e0"},
-    {file = "wrapt-1.17.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40d615e4fe22f4ad3528448c193b218e077656ca9ccb22ce2cb20db730f8d306"},
-    {file = "wrapt-1.17.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5aaeff38654462bc4b09023918b7f21790efb807f54c000a39d41d69cf552cb"},
-    {file = "wrapt-1.17.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a7d15bbd2bc99e92e39f49a04653062ee6085c0e18b3b7512a4f2fe91f2d681"},
-    {file = "wrapt-1.17.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e3890b508a23299083e065f435a492b5435eba6e304a7114d2f919d400888cc6"},
-    {file = "wrapt-1.17.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8c8b293cd65ad716d13d8dd3624e42e5a19cc2a2f1acc74b30c2c13f15cb61a6"},
-    {file = "wrapt-1.17.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c82b8785d98cdd9fed4cac84d765d234ed3251bd6afe34cb7ac523cb93e8b4f"},
-    {file = "wrapt-1.17.2-cp313-cp313t-win32.whl", hash = "sha256:13e6afb7fe71fe7485a4550a8844cc9ffbe263c0f1a1eea569bc7091d4898555"},
-    {file = "wrapt-1.17.2-cp313-cp313t-win_amd64.whl", hash = "sha256:eaf675418ed6b3b31c7a989fd007fa7c3be66ce14e5c3b27336383604c9da85c"},
-    {file = "wrapt-1.17.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5c803c401ea1c1c18de70a06a6f79fcc9c5acfc79133e9869e730ad7f8ad8ef9"},
-    {file = "wrapt-1.17.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f917c1180fdb8623c2b75a99192f4025e412597c50b2ac870f156de8fb101119"},
-    {file = "wrapt-1.17.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ecc840861360ba9d176d413a5489b9a0aff6d6303d7e733e2c4623cfa26904a6"},
-    {file = "wrapt-1.17.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb87745b2e6dc56361bfde481d5a378dc314b252a98d7dd19a651a3fa58f24a9"},
-    {file = "wrapt-1.17.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58455b79ec2661c3600e65c0a716955adc2410f7383755d537584b0de41b1d8a"},
-    {file = "wrapt-1.17.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4e42a40a5e164cbfdb7b386c966a588b1047558a990981ace551ed7e12ca9c2"},
-    {file = "wrapt-1.17.2-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:91bd7d1773e64019f9288b7a5101f3ae50d3d8e6b1de7edee9c2ccc1d32f0c0a"},
-    {file = "wrapt-1.17.2-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:bb90fb8bda722a1b9d48ac1e6c38f923ea757b3baf8ebd0c82e09c5c1a0e7a04"},
-    {file = "wrapt-1.17.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:08e7ce672e35efa54c5024936e559469436f8b8096253404faeb54d2a878416f"},
-    {file = "wrapt-1.17.2-cp38-cp38-win32.whl", hash = "sha256:410a92fefd2e0e10d26210e1dfb4a876ddaf8439ef60d6434f21ef8d87efc5b7"},
-    {file = "wrapt-1.17.2-cp38-cp38-win_amd64.whl", hash = "sha256:95c658736ec15602da0ed73f312d410117723914a5c91a14ee4cdd72f1d790b3"},
-    {file = "wrapt-1.17.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:99039fa9e6306880572915728d7f6c24a86ec57b0a83f6b2491e1d8ab0235b9a"},
-    {file = "wrapt-1.17.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2696993ee1eebd20b8e4ee4356483c4cb696066ddc24bd70bcbb80fa56ff9061"},
-    {file = "wrapt-1.17.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:612dff5db80beef9e649c6d803a8d50c409082f1fedc9dbcdfde2983b2025b82"},
-    {file = "wrapt-1.17.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62c2caa1585c82b3f7a7ab56afef7b3602021d6da34fbc1cf234ff139fed3cd9"},
-    {file = "wrapt-1.17.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c958bcfd59bacc2d0249dcfe575e71da54f9dcf4a8bdf89c4cb9a68a1170d73f"},
-    {file = "wrapt-1.17.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc78a84e2dfbc27afe4b2bd7c80c8db9bca75cc5b85df52bfe634596a1da846b"},
-    {file = "wrapt-1.17.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ba0f0eb61ef00ea10e00eb53a9129501f52385c44853dbd6c4ad3f403603083f"},
-    {file = "wrapt-1.17.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1e1fe0e6ab7775fd842bc39e86f6dcfc4507ab0ffe206093e76d61cde37225c8"},
-    {file = "wrapt-1.17.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c86563182421896d73858e08e1db93afdd2b947a70064b813d515d66549e15f9"},
-    {file = "wrapt-1.17.2-cp39-cp39-win32.whl", hash = "sha256:f393cda562f79828f38a819f4788641ac7c4085f30f1ce1a68672baa686482bb"},
-    {file = "wrapt-1.17.2-cp39-cp39-win_amd64.whl", hash = "sha256:36ccae62f64235cf8ddb682073a60519426fdd4725524ae38874adf72b5f2aeb"},
-    {file = "wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8"},
-    {file = "wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3"},
-]
 
 [[package]]
 name = "yarl"
@@ -1522,4 +1482,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3ba0239d0fb80bfe4e1bdde885559f17cd56d56e051e58342ddd650aedb7bdee"
+content-hash = "d96d2ca8d983fae1e5c4df3b48f4707a46a981647ecd7f31cb5047d5a66fa2b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ flake8 = "^7.1.1"
 isort = {extras = ["pyproject"], version = "^6.0.0"}
 mypy = "^1.14"
 pydocstyle = "^6.3.0"
+pytest = "^8.3.5"
 
 [tool.poetry.scripts]
 feedly-regexp-marker = "feedly_regexp_marker.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 profile = "black"
 
 [tool.mypy]
+check_untyped_defs = true
 plugins = "pydantic.mypy"
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ check_untyped_defs = true
 plugins = "pydantic.mypy"
 
 [[tool.mypy.overrides]]
-module = ["feedly.*", "logzero.*"]
+module = ["feedly.*", "logzero.*", "ruamel.*"]
 ignore_missing_imports = true
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ python = "^3.9"
 aiohttp = "^3.10.11"
 feedly-client = "^0.23.2"
 logzero = "^1.7.0"
-pydantic = "^1.9.0"
-pydantic-yaml = {extras = ["ruamel"], version = "^0.6.3"}
+pydantic = "^2.11.3"
+pydantic-yaml = "^1.4.0"
 typer = "^0.15.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,8 +1,10 @@
 import pytest
 from pydantic import ValidationError
 
-from feedly_regexp_marker.classifier import RulePatternIndex
+from feedly_regexp_marker.classifier import EntryAttr, RulePatternIndex
+from feedly_regexp_marker.feedly_controller import Action, StreamId
 from feedly_regexp_marker.pattern_texts import PatternTexts
+from feedly_regexp_marker.rules import EntryPatternTexts, Rule
 
 # === Test RulePatternIndex ===
 
@@ -160,3 +162,163 @@ class TestRulePatternIndex:
         # --- Test commutativity (a | b == b | a) ---
         result_reversed = rpi2 | rpi1
         assert result_reversed.root == expected_rpi.root
+
+    # --- Test from_rule ---
+    def test_from_rule_basic_title_only(self):
+        """Test from_rule with 1 action, 1 stream, title pattern only."""
+        rule = Rule(
+            stream_ids=frozenset(["s1"]),
+            actions=frozenset(["markAsRead"]),
+            patterns=EntryPatternTexts(title=PatternTexts(["A"])),
+        )
+        rpi = RulePatternIndex.from_rule(rule)
+
+        expected_key_t = ("markAsRead", "s1", "title")
+        expected_key_c = ("markAsRead", "s1", "content")
+        expected_root = {
+            expected_key_t: PatternTexts(["A"]),
+            expected_key_c: PatternTexts(),  # model_dump() includes empty content
+        }
+        assert rpi.root == expected_root
+
+    def test_from_rule_basic_content_only(self):
+        """Test from_rule with 1 action, 1 stream, content pattern only."""
+        rule = Rule(
+            stream_ids=frozenset(["s1"]),
+            actions=frozenset(["markAsRead"]),
+            patterns=EntryPatternTexts(content=PatternTexts(["X"])),
+        )
+        rpi = RulePatternIndex.from_rule(rule)
+
+        expected_key_t = ("markAsRead", "s1", "title")
+        expected_key_c = ("markAsRead", "s1", "content")
+        expected_root = {
+            expected_key_t: PatternTexts(),  # model_dump() includes empty title
+            expected_key_c: PatternTexts(["X"]),
+        }
+        assert rpi.root == expected_root
+
+    def test_from_rule_both_attrs(self):
+        """Test from_rule with 1 action, 1 stream, both title and content patterns."""
+        rule = Rule(
+            stream_ids=frozenset(["s1"]),
+            actions=frozenset(["markAsRead"]),
+            patterns=EntryPatternTexts(
+                title=PatternTexts(["A"]), content=PatternTexts(["X"])
+            ),
+        )
+        rpi = RulePatternIndex.from_rule(rule)
+
+        expected_key_t = ("markAsRead", "s1", "title")
+        expected_key_c = ("markAsRead", "s1", "content")
+        expected_root = {
+            expected_key_t: PatternTexts(["A"]),
+            expected_key_c: PatternTexts(["X"]),
+        }
+        assert rpi.root == expected_root
+
+    def test_from_rule_multiple_actions(self):
+        """Test from_rule with multiple actions."""
+        rule = Rule(
+            stream_ids=frozenset(["s1"]),
+            actions=frozenset(["markAsRead", "markAsSaved"]),  # Multiple actions
+            patterns=EntryPatternTexts(title=PatternTexts(["A"])),
+        )
+        rpi = RulePatternIndex.from_rule(rule)
+
+        expected_key_read_t = ("markAsRead", "s1", "title")
+        expected_key_read_c = ("markAsRead", "s1", "content")
+        expected_key_save_t = ("markAsSaved", "s1", "title")
+        expected_key_save_c = ("markAsSaved", "s1", "content")
+        expected_root = {
+            expected_key_read_t: PatternTexts(["A"]),
+            expected_key_read_c: PatternTexts(),
+            expected_key_save_t: PatternTexts(["A"]),
+            expected_key_save_c: PatternTexts(),
+        }
+        assert rpi.root == expected_root
+
+    def test_from_rule_multiple_streams(self):
+        """Test from_rule with multiple stream IDs."""
+        rule = Rule(
+            stream_ids=frozenset(["s1", "s2"]),  # Multiple streams
+            actions=frozenset(["markAsRead"]),
+            patterns=EntryPatternTexts(title=PatternTexts(["A"])),
+        )
+        rpi = RulePatternIndex.from_rule(rule)
+
+        expected_key_s1_t = ("markAsRead", "s1", "title")
+        expected_key_s1_c = ("markAsRead", "s1", "content")
+        expected_key_s2_t = ("markAsRead", "s2", "title")
+        expected_key_s2_c = ("markAsRead", "s2", "content")
+        expected_root = {
+            expected_key_s1_t: PatternTexts(["A"]),
+            expected_key_s1_c: PatternTexts(),
+            expected_key_s2_t: PatternTexts(["A"]),
+            expected_key_s2_c: PatternTexts(),
+        }
+        assert rpi.root == expected_root
+
+    def test_from_rule_multiple_actions_and_streams(self):
+        """Test from_rule with multiple actions and stream IDs."""
+        rule = Rule(
+            stream_ids=frozenset(["s1", "s2"]),
+            actions=frozenset(["markAsRead", "markAsSaved"]),
+            patterns=EntryPatternTexts(title=PatternTexts(["A"])),
+        )
+        rpi = RulePatternIndex.from_rule(rule)
+
+        expected_keys: list[tuple[Action, StreamId, EntryAttr]] = [
+            ("markAsRead", "s1", "title"),
+            ("markAsRead", "s2", "title"),
+            ("markAsSaved", "s1", "title"),
+            ("markAsSaved", "s2", "title"),
+            ("markAsRead", "s1", "content"),
+            ("markAsRead", "s2", "content"),
+            ("markAsSaved", "s1", "content"),
+            ("markAsSaved", "s2", "content"),
+        ]
+        assert len(rpi.root) == len(expected_keys)
+        for key in expected_keys:
+            assert key in rpi.root
+            if key[2] == "title":
+                assert rpi.root[key] == PatternTexts(["A"])
+            else:
+                assert rpi.root[key] == PatternTexts()  # Empty content
+
+    def test_from_rule_no_patterns(self):
+        """Test from_rule with empty patterns results in keys with empty PatternTexts."""
+        rule = Rule(
+            stream_ids=frozenset(["s1"]),
+            actions=frozenset(["markAsRead"]),
+            patterns=EntryPatternTexts(),  # Empty patterns
+        )
+        rpi = RulePatternIndex.from_rule(rule)
+
+        expected_key_t = ("markAsRead", "s1", "title")
+        expected_key_c = ("markAsRead", "s1", "content")
+        expected_root = {
+            expected_key_t: PatternTexts(),
+            expected_key_c: PatternTexts(),
+        }
+        assert rpi.root == expected_root
+
+    def test_from_rule_empty_actions_or_streams(self):
+        """Test from_rule with empty actions or stream_ids results in an empty index."""
+        # Empty actions
+        rule_empty_actions = Rule(
+            stream_ids=frozenset(["s1"]),
+            actions=frozenset(),  # Empty
+            patterns=EntryPatternTexts(title=PatternTexts(["A"])),
+        )
+        rpi_empty_actions = RulePatternIndex.from_rule(rule_empty_actions)
+        assert rpi_empty_actions.root == {}
+
+        # Empty streams
+        rule_empty_streams = Rule(
+            stream_ids=frozenset(),  # Empty
+            actions=frozenset(["markAsRead"]),
+            patterns=EntryPatternTexts(title=PatternTexts(["A"])),
+        )
+        rpi_empty_streams = RulePatternIndex.from_rule(rule_empty_streams)
+        assert rpi_empty_streams.root == {}

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -37,3 +37,126 @@ class TestRulePatternIndex:
         with pytest.raises(ValidationError):
             # Pydantic v2 raises ValidationError on mutation attempts for frozen models
             rpi.root = {}  # type: ignore[misc]
+
+    # --- Test __or__ operator ---
+    @pytest.mark.parametrize(
+        "rpi1_data, rpi2_data, expected_root_data",
+        [
+            pytest.param({}, {}, {}, id="empty_or_empty"),
+            pytest.param(
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_A"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(),
+                },
+                {},
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_A"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(),
+                },
+                id="nonempty_or_empty",
+            ),
+            pytest.param(
+                {},
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_A"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(),
+                },
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_A"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(),
+                },
+                id="empty_or_nonempty",
+            ),
+            pytest.param(
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_A"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(),
+                },
+                {
+                    ("markAsSaved", "s1", "title"): PatternTexts(["title_B"]),
+                    ("markAsSaved", "s1", "content"): PatternTexts(),
+                },
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_A"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(),
+                    ("markAsSaved", "s1", "title"): PatternTexts(["title_B"]),
+                    ("markAsSaved", "s1", "content"): PatternTexts(),
+                },
+                id="disjoint_keys",
+            ),
+            pytest.param(
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_A"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(),
+                },
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_B"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(),
+                },  # Overlaps key
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(
+                        ["title_A", "title_B"]
+                    ),  # Merged PatternTexts
+                    (
+                        "markAsRead",
+                        "s1",
+                        "content",
+                    ): PatternTexts(),  # Merged empty PatternTexts
+                },
+                id="overlapping_keys",
+            ),
+            pytest.param(
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_A"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(["content_X"]),
+                },
+                {
+                    ("markAsSaved", "s1", "title"): PatternTexts(["title_B"]),
+                    ("markAsSaved", "s1", "content"): PatternTexts(),
+                },
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_A"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(["content_X"]),
+                    ("markAsSaved", "s1", "title"): PatternTexts(["title_B"]),
+                    ("markAsSaved", "s1", "content"): PatternTexts(),
+                },
+                id="mixed_overlap",
+            ),
+            pytest.param(  # Idempotency check
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_A"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(["content_X"]),
+                },
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_A"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(["content_X"]),
+                },
+                {
+                    ("markAsRead", "s1", "title"): PatternTexts(["title_A"]),
+                    ("markAsRead", "s1", "content"): PatternTexts(["content_X"]),
+                },
+                id="idempotency",
+            ),
+        ],
+    )
+    def test_or_operator(
+        self, rpi1_data: dict, rpi2_data: dict, expected_root_data: dict
+    ):
+        """Tests the __or__ operator for RulePatternIndex using parametrize."""
+        rpi1 = RulePatternIndex(root=rpi1_data)
+        rpi2 = RulePatternIndex(root=rpi2_data)
+        expected_rpi = RulePatternIndex(root=expected_root_data)
+
+        # --- Test the | operator ---
+        result = rpi1 | rpi2
+        assert isinstance(result, RulePatternIndex)
+        assert result.root == expected_rpi.root
+        assert result.model_config.get("frozen") is True  # Ensure result is also frozen
+
+        # --- Test immutability of original instances ---
+        assert rpi1.root == rpi1_data
+        assert rpi2.root == rpi2_data
+
+        # --- Test commutativity (a | b == b | a) ---
+        result_reversed = rpi2 | rpi1
+        assert result_reversed.root == expected_rpi.root

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,39 @@
+import pytest
+from pydantic import ValidationError
+
+from feedly_regexp_marker.classifier import RulePatternIndex
+from feedly_regexp_marker.pattern_texts import PatternTexts
+
+# === Test RulePatternIndex ===
+
+
+class TestRulePatternIndex:
+
+    # --- Test Initialization and Immutability ---
+    @pytest.mark.parametrize(
+        "init_kwargs, expected_root",
+        [
+            pytest.param({}, {}, id="no_args"),
+            pytest.param({"root": None}, {}, id="root_none"),
+            pytest.param({"root": {}}, {}, id="root_empty_dict"),
+            pytest.param(
+                {"root": {("markAsRead", "s1", "title"): PatternTexts(["title"])}},
+                {("markAsRead", "s1", "title"): PatternTexts(["title"])},
+                id="with_data",
+            ),
+        ],
+    )
+    def test_initialization(self, init_kwargs: dict, expected_root: dict):
+        """Tests RulePatternIndex initialization for various scenarios."""
+        rpi = RulePatternIndex(**init_kwargs)
+        assert rpi.root == expected_root
+        assert rpi.model_config.get("frozen") is True
+
+    def test_frozen(self):
+        """Test RulePatternIndex is immutable due to frozen=True."""
+        rpi = RulePatternIndex(
+            root={("markAsRead", "s1", "title"): PatternTexts(["title"])}
+        )
+        with pytest.raises(ValidationError):
+            # Pydantic v2 raises ValidationError on mutation attempts for frozen models
+            rpi.root = {}  # type: ignore[misc]

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,113 @@
+import re
+
+import pytest
+
+from feedly_regexp_marker.classifier import PatternTexts
+from feedly_regexp_marker.rules import PatternText
+
+# --- Test Cases for PatternTexts.__or__ ---
+
+
+@pytest.mark.parametrize(
+    "set1, set2, expected_set",
+    [
+        pytest.param(frozenset(), frozenset(), frozenset(), id="empty_or_empty"),
+        pytest.param(
+            frozenset(["a"]), frozenset(), frozenset(["a"]), id="nonempty_or_empty"
+        ),
+        pytest.param(
+            frozenset(), frozenset(["a"]), frozenset(["a"]), id="empty_or_nonempty"
+        ),
+        pytest.param(
+            frozenset(["a", "b"]),
+            frozenset(["c"]),
+            frozenset(["a", "b", "c"]),
+            id="disjoint_sets",
+        ),
+        pytest.param(
+            frozenset(["a", "b"]),
+            frozenset(["b", "c"]),
+            frozenset(["a", "b", "c"]),
+            id="overlapping_sets",
+        ),
+        pytest.param(
+            frozenset(["a"]), frozenset(["a"]), frozenset(["a"]), id="identical_sets"
+        ),
+    ],
+)
+def test_pattern_texts_or(
+    set1: frozenset[PatternText],
+    set2: frozenset[PatternText],
+    expected_set: frozenset[PatternText],
+):
+    """Tests the __or__ operator for PatternTexts using parametrize."""
+    pt1 = PatternTexts(root=set1)
+    pt2 = PatternTexts(root=set2)
+
+    # --- Test the | operator ---
+    result = pt1 | pt2
+    assert isinstance(result, PatternTexts)
+    assert result.root == expected_set
+
+    # --- Test immutability of original instances ---
+    assert pt1.root == set1
+    assert pt2.root == set2
+
+    # --- Test commutativity (a | b == b | a) ---
+    result_reversed = pt2 | pt1
+    assert result_reversed.root == expected_set
+
+
+# --- Test Cases for PatternTexts.compile ---
+
+
+def test_pattern_texts_compile_empty():
+    """Test compiling an empty PatternTexts instance."""
+    pt_empty = PatternTexts(root=frozenset())
+    compiled = pt_empty.compile()
+    assert compiled is None
+
+
+def test_pattern_texts_compile_single_pattern():
+    """Test compiling a PatternTexts instance with a single pattern."""
+    pattern = "^start"
+    pt_single = PatternTexts(root=frozenset([pattern]))
+    compiled = pt_single.compile()
+
+    assert isinstance(compiled, re.Pattern)
+    assert compiled.pattern == pattern
+    assert compiled.search("start of line")
+    assert not compiled.search("middle start")
+
+
+def test_pattern_texts_compile_multiple_patterns():
+    """Test compiling a PatternTexts instance with multiple patterns."""
+    patterns = frozenset(["apple", "banana", r"\d+"])
+    pt_multiple = PatternTexts(root=patterns)
+    compiled = pt_multiple.compile()
+
+    assert isinstance(compiled, re.Pattern)
+    assert all(p in compiled.pattern for p in patterns)
+    assert "|" in compiled.pattern
+
+    # Test matching
+    assert compiled.search("I like apple pie")
+    assert compiled.search("banana bread is good")
+    assert compiled.search("the number is 123")
+    assert not compiled.search("only orange")
+    assert not compiled.search("no digits here")
+
+
+def test_pattern_texts_compile_special_chars():
+    """Test compiling patterns with regex special characters."""
+    patterns = frozenset([r"^\d+$", r"end\."])  # Start/end anchors, escaped dot
+    pt_special = PatternTexts(root=patterns)
+    compiled = pt_special.compile()
+
+    assert isinstance(compiled, re.Pattern)
+    assert all(p in compiled.pattern for p in patterns)
+
+    assert compiled.search("12345")  # Matches ^\d+$
+    assert not compiled.search("123a")
+    assert compiled.search("this is the end.")  # Matches end\.
+    assert not compiled.search("this is the end?")

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -440,11 +440,11 @@ class TestClassifier:
         assert compiled2 is None  # Empty PatternTexts should compile to None
         assert isinstance(compiled3, re.Pattern)
 
-    # --- Test __to_act ---
+    # --- Test to_act ---
     @pytest.fixture
     def classifier_for_to_act(self) -> Classifier:
-        """Provides a Classifier instance for __to_act tests."""
-        # Define specific compiled rules for testing __to_act logic
+        """Provides a Classifier instance for to_act tests."""
+        # Define specific compiled rules for testing to_act logic
         compiled_rules: dict[
             tuple[Action, StreamId, EntryAttr], Optional[re.Pattern]
         ] = {
@@ -460,7 +460,7 @@ class TestClassifier:
         }
         return Classifier(compiled_rule_index=compiled_rules)
 
-    # --- Test cases for __to_act ---
+    # --- Test cases for to_act ---
     @pytest.mark.parametrize(
         "entry_data, action, expected_result",
         [

--- a/tests/test_pattern_texts.py
+++ b/tests/test_pattern_texts.py
@@ -1,9 +1,40 @@
 import re
 
 import pytest
+from pydantic import ValidationError
 
-from feedly_regexp_marker.classifier import PatternTexts
-from feedly_regexp_marker.rules import PatternText
+from feedly_regexp_marker.pattern_texts import PatternText, PatternTexts
+
+# --- Test Cases for PatternTexts ---
+
+
+def test_pattern_texts_defaults():
+    """Test PatternTexts initializes with default empty frozenset."""
+    patterns = PatternTexts()
+    assert patterns.root == frozenset()
+    assert patterns.model_config.get("frozen") is True
+
+
+def test_pattern_texts_with_data():
+    """Test PatternTexts initialization with data."""
+    data: frozenset[PatternText] = frozenset(["^Important:", "Alert"])
+    patterns = PatternTexts(root=data)
+    assert patterns.root == data
+
+
+def test_pattern_texts_empty_patterntext():
+    """Test PatternTexts initialization with empty PatternText."""
+    with pytest.raises(ValidationError):
+        PatternTexts(root=frozenset([""]))
+
+
+def test_pattern_texts_frozen():
+    """Test PatternTexts is immutable."""
+    patterns = PatternTexts(root=frozenset(["test"]))
+    with pytest.raises(ValidationError):
+        # Pydantic v2 raises ValidationError on mutation attempts for frozen models
+        patterns.root = frozenset(["new"])  # type: ignore[misc]
+
 
 # --- Test Cases for PatternTexts.__or__ ---
 

--- a/tests/test_pattern_texts.py
+++ b/tests/test_pattern_texts.py
@@ -9,18 +9,35 @@ from feedly_regexp_marker.pattern_texts import PatternText, PatternTexts
 # --- Test Cases for PatternTexts ---
 
 
-def test_pattern_texts_defaults():
-    """Test PatternTexts initializes with default empty frozenset."""
-    patterns = PatternTexts()
-    assert patterns.root == frozenset()
-    assert patterns.model_config.get("frozen") is True
-
-
-def test_pattern_texts_with_data():
-    """Test PatternTexts initialization with data."""
-    data: frozenset[PatternText] = frozenset(["^Important:", "Alert"])
-    patterns = PatternTexts(root=data)
-    assert patterns.root == data
+@pytest.mark.parametrize(
+    "init_kwargs, expected_root",
+    [
+        pytest.param({}, frozenset(), id="no_args"),
+        pytest.param({"root": frozenset()}, frozenset(), id="explicit_empty_frozenset"),
+        pytest.param(
+            {"root": frozenset(["^Important:", "Alert"])},
+            frozenset(["^Important:", "Alert"]),
+            id="init_with_frozenset",
+        ),
+        pytest.param(
+            {"root": ["^Important:", "Alert"]},
+            frozenset(["^Important:", "Alert"]),
+            id="init_with_list",
+        ),
+        pytest.param(
+            {"root": tuple(["^Important:", "Alert"])},
+            frozenset(["^Important:", "Alert"]),
+            id="init_with_tuple",
+        ),
+    ],
+)
+def test_pattern_texts_initialization(
+    init_kwargs: dict, expected_root: frozenset[PatternText]
+):
+    """Tests PatternTexts initialization for various valid inputs."""
+    pt = PatternTexts(**init_kwargs)
+    assert pt.root == expected_root
+    assert pt.model_config.get("frozen") is True
 
 
 def test_pattern_texts_empty_patterntext():

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -33,6 +33,14 @@ def test_entry_pattern_texts_with_data():
     assert patterns.content == content_patterns
 
 
+def test_entry_pattern_texts_empty_patterntext():
+    """Test EntryPatternTexts initialization with empty PatternText."""
+    with pytest.raises(ValidationError):
+        EntryPatternTexts(title=frozenset([""]))
+    with pytest.raises(ValidationError):
+        EntryPatternTexts(content=frozenset([""]))
+
+
 def test_entry_pattern_texts_frozen():
     """Test EntryPatternTexts is immutable."""
     patterns = EntryPatternTexts(title=frozenset(["test"]))

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -11,7 +11,7 @@ from feedly_regexp_marker.rules import Action, EntryPatternTexts, Rule, Rules, S
 
 
 def test_entry_pattern_texts_defaults():
-    """Test EntryPatternTexts initializes with default empty frozensets."""
+    """Test EntryPatternTexts initializes with default empty PatternTexts."""
     patterns = EntryPatternTexts()
     assert patterns.title == PatternTexts()
     assert patterns.content == PatternTexts()
@@ -29,7 +29,7 @@ def test_entry_pattern_texts_with_data():
 
 def test_entry_pattern_texts_frozen():
     """Test EntryPatternTexts is immutable."""
-    patterns = EntryPatternTexts(title=frozenset(["test"]))
+    patterns = EntryPatternTexts(title=PatternTexts(frozenset(["test"])))
     with pytest.raises(ValidationError):
         # Pydantic v2 raises ValidationError on mutation attempts for frozen models
         patterns.title = PatternTexts(frozenset(["new"]))  # type: ignore[misc]
@@ -59,7 +59,8 @@ def test_rule_with_data():
     stream_ids: frozenset[StreamId] = frozenset(["feed/1", "feed/2"])
     actions: frozenset[Action] = frozenset(["markAsRead", "markAsSaved"])
     patterns = EntryPatternTexts(
-        title=frozenset(["Title Pattern"]), content=frozenset(["Content Pattern"])
+        title=PatternTexts(frozenset(["Title Pattern"])),
+        content=PatternTexts(frozenset(["Content Pattern"])),
     )
     name = "My Test Rule"
     rule = Rule(stream_ids=stream_ids, actions=actions, patterns=patterns, name=name)
@@ -84,7 +85,7 @@ def test_rule_frozen():
     with pytest.raises(ValidationError):
         rule.actions = frozenset(["markAsSaved"])  # type: ignore[misc]
     with pytest.raises(ValidationError):
-        rule.patterns = EntryPatternTexts(title=frozenset(["new"]))  # type: ignore[misc]
+        rule.patterns = EntryPatternTexts(title=PatternTexts(frozenset(["new"])))  # type: ignore[misc]
 
 
 # --- Test Rules ---
@@ -96,7 +97,7 @@ def sample_rule1() -> Rule:
     return Rule(
         stream_ids=frozenset(["feed/1"]),
         actions=frozenset(["markAsRead"]),
-        patterns=EntryPatternTexts(title=frozenset(["Rule1 Title"])),
+        patterns=EntryPatternTexts(title=PatternTexts(frozenset(["Rule1 Title"]))),
         name="Rule 1",
     )
 
@@ -106,7 +107,7 @@ def sample_rule2() -> Rule:
     return Rule(
         stream_ids=frozenset(["feed/2", "feed/3"]),
         actions=frozenset(["markAsSaved"]),
-        patterns=EntryPatternTexts(content=frozenset(["Rule2 Content"])),
+        patterns=EntryPatternTexts(content=PatternTexts(frozenset(["Rule2 Content"]))),
         name="Rule 2",
     )
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -4,14 +4,8 @@ import pytest
 from pydantic import ValidationError
 from ruamel.yaml.parser import ParserError
 
-from feedly_regexp_marker.rules import (
-    Action,
-    EntryPatternTexts,
-    PatternText,
-    Rule,
-    Rules,
-    StreamId,
-)
+from feedly_regexp_marker.pattern_texts import PatternTexts
+from feedly_regexp_marker.rules import Action, EntryPatternTexts, Rule, Rules, StreamId
 
 # --- Test EntryPatternTexts ---
 
@@ -19,26 +13,18 @@ from feedly_regexp_marker.rules import (
 def test_entry_pattern_texts_defaults():
     """Test EntryPatternTexts initializes with default empty frozensets."""
     patterns = EntryPatternTexts()
-    assert patterns.title == frozenset()
-    assert patterns.content == frozenset()
+    assert patterns.title == PatternTexts()
+    assert patterns.content == PatternTexts()
     assert patterns.model_config.get("frozen") is True
 
 
 def test_entry_pattern_texts_with_data():
     """Test EntryPatternTexts initialization with data."""
-    title_patterns: frozenset[PatternText] = frozenset(["^Important:", "Alert"])
-    content_patterns: frozenset[PatternText] = frozenset(["keyword1", "keyword2"])
+    title_patterns = PatternTexts(frozenset(["^Important:", "Alert"]))
+    content_patterns = PatternTexts(frozenset(["keyword1", "keyword2"]))
     patterns = EntryPatternTexts(title=title_patterns, content=content_patterns)
     assert patterns.title == title_patterns
     assert patterns.content == content_patterns
-
-
-def test_entry_pattern_texts_empty_patterntext():
-    """Test EntryPatternTexts initialization with empty PatternText."""
-    with pytest.raises(ValidationError):
-        EntryPatternTexts(title=frozenset([""]))
-    with pytest.raises(ValidationError):
-        EntryPatternTexts(content=frozenset([""]))
 
 
 def test_entry_pattern_texts_frozen():
@@ -46,9 +32,9 @@ def test_entry_pattern_texts_frozen():
     patterns = EntryPatternTexts(title=frozenset(["test"]))
     with pytest.raises(ValidationError):
         # Pydantic v2 raises ValidationError on mutation attempts for frozen models
-        patterns.title = frozenset(["new"])  # type: ignore[misc]
+        patterns.title = PatternTexts(frozenset(["new"]))  # type: ignore[misc]
     with pytest.raises(ValidationError):
-        patterns.content = frozenset(["new"])  # type: ignore[misc]
+        patterns.content = PatternTexts(frozenset(["new"]))  # type: ignore[misc]
 
 
 # --- Test Rule ---

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,229 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+from ruamel.yaml.parser import ParserError
+
+from feedly_regexp_marker.rules import (
+    Action,
+    EntryPatternTexts,
+    PatternText,
+    Rule,
+    Rules,
+    StreamId,
+)
+
+# --- Test EntryPatternTexts ---
+
+
+def test_entry_pattern_texts_defaults():
+    """Test EntryPatternTexts initializes with default empty frozensets."""
+    patterns = EntryPatternTexts()
+    assert patterns.title == frozenset()
+    assert patterns.content == frozenset()
+    assert patterns.model_config.get("frozen") is True
+
+
+def test_entry_pattern_texts_with_data():
+    """Test EntryPatternTexts initialization with data."""
+    title_patterns: frozenset[PatternText] = frozenset(["^Important:", "Alert"])
+    content_patterns: frozenset[PatternText] = frozenset(["keyword1", "keyword2"])
+    patterns = EntryPatternTexts(title=title_patterns, content=content_patterns)
+    assert patterns.title == title_patterns
+    assert patterns.content == content_patterns
+
+
+def test_entry_pattern_texts_frozen():
+    """Test EntryPatternTexts is immutable."""
+    patterns = EntryPatternTexts(title=frozenset(["test"]))
+    with pytest.raises(ValidationError):
+        # Pydantic v2 raises ValidationError on mutation attempts for frozen models
+        patterns.title = frozenset(["new"])  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        patterns.content = frozenset(["new"])  # type: ignore[misc]
+
+
+# --- Test Rule ---
+
+
+def test_rule_minimal():
+    """Test minimal Rule initialization."""
+    stream_ids: frozenset[StreamId] = frozenset(["feed/http://example.com/rss"])
+    actions: frozenset[Action] = frozenset(["markAsRead"])
+    patterns = EntryPatternTexts()
+    rule = Rule(stream_ids=stream_ids, actions=actions, patterns=patterns)
+
+    assert rule.stream_ids == stream_ids
+    assert rule.actions == actions
+    assert rule.patterns == patterns
+    assert rule.name is None
+    assert rule.model_config.get("frozen") is True
+
+
+def test_rule_with_data():
+    """Test Rule initialization with more data."""
+    stream_ids: frozenset[StreamId] = frozenset(["feed/1", "feed/2"])
+    actions: frozenset[Action] = frozenset(["markAsRead", "markAsSaved"])
+    patterns = EntryPatternTexts(
+        title=frozenset(["Title Pattern"]), content=frozenset(["Content Pattern"])
+    )
+    name = "My Test Rule"
+    rule = Rule(stream_ids=stream_ids, actions=actions, patterns=patterns, name=name)
+
+    assert rule.stream_ids == stream_ids
+    assert rule.actions == actions
+    assert rule.patterns == patterns
+    assert rule.name == name
+
+
+def test_rule_frozen():
+    """Test Rule is immutable."""
+    rule = Rule(
+        stream_ids=frozenset(["feed/1"]),
+        actions=frozenset(["markAsRead"]),
+        patterns=EntryPatternTexts(),
+    )
+    with pytest.raises(ValidationError):
+        rule.name = "New Name"  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        rule.stream_ids = frozenset(["feed/2"])  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        rule.actions = frozenset(["markAsSaved"])  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        rule.patterns = EntryPatternTexts(title=frozenset(["new"]))  # type: ignore[misc]
+
+
+# --- Test Rules ---
+
+
+# Fixtures from existing tests (assuming they are in the same file or imported)
+@pytest.fixture
+def sample_rule1() -> Rule:
+    return Rule(
+        stream_ids=frozenset(["feed/1"]),
+        actions=frozenset(["markAsRead"]),
+        patterns=EntryPatternTexts(title=frozenset(["Rule1 Title"])),
+        name="Rule 1",
+    )
+
+
+@pytest.fixture
+def sample_rule2() -> Rule:
+    return Rule(
+        stream_ids=frozenset(["feed/2", "feed/3"]),
+        actions=frozenset(["markAsSaved"]),
+        patterns=EntryPatternTexts(content=frozenset(["Rule2 Content"])),
+        name="Rule 2",
+    )
+
+
+def test_rules_initialization(sample_rule1: Rule, sample_rule2: Rule):
+    """Test Rules initialization with a set of Rule objects."""
+    rule_set = frozenset([sample_rule1, sample_rule2])
+    rules = Rules(root=rule_set)
+    assert rules.root == rule_set
+    assert rules.model_config.get("frozen") is True
+
+
+def test_rules_iteration(sample_rule1: Rule, sample_rule2: Rule):
+    """Test iterating over Rules yields the individual Rule objects."""
+    rule_set = frozenset([sample_rule1, sample_rule2])
+    rules = Rules(root=rule_set)
+    iterated_rules = list(rules)  # Uses the __iter__ method
+    assert len(iterated_rules) == 2
+    assert sample_rule1 in iterated_rules
+    assert sample_rule2 in iterated_rules
+
+
+def test_rules_frozen(sample_rule1: Rule):
+    """Test Rules is immutable."""
+    rules = Rules(root=frozenset([sample_rule1]))
+    with pytest.raises(ValidationError):
+        rules.root = frozenset()  # type: ignore[misc]
+
+
+# --- Test Rules.from_yaml ---
+
+
+def test_rules_from_yaml(tmp_path: Path, sample_rule1: Rule, sample_rule2: Rule):
+    """Test loading Rules from a valid YAML file."""
+    yaml_content = """
+- stream_ids:
+  - feed/1
+  actions:
+  - markAsRead
+  patterns:
+    title:
+    - Rule1 Title
+  name: Rule 1
+- stream_ids:
+  - feed/2
+  - feed/3
+  actions:
+  - markAsSaved
+  patterns:
+    content:
+    - Rule2 Content
+  name: Rule 2
+"""
+    yaml_file = tmp_path / "rules.yaml"
+    yaml_file.write_text(yaml_content)
+
+    loaded_rules = Rules.from_yaml(yaml_file)
+
+    expected_rules = Rules(root=frozenset([sample_rule1, sample_rule2]))
+
+    # Compare frozensets directly (order doesn't matter)
+    assert loaded_rules.root == expected_rules.root
+
+
+def test_rules_from_empty_yaml(tmp_path: Path):
+    """Test loading Rules from an empty YAML file (valid YAML list)."""
+    yaml_content = "[]"  # Represents an empty list/set of rules
+    yaml_file = tmp_path / "empty_rules.yaml"
+    yaml_file.write_text(yaml_content)
+
+    loaded_rules = Rules.from_yaml(yaml_file)
+    assert loaded_rules.root == frozenset()
+
+
+def test_rules_from_invalid_yaml_structure(tmp_path: Path):
+    """Test loading Rules from YAML with invalid structure for Pydantic."""
+    # stream_ids should be a list/set of strings, not int
+    yaml_content = """
+- stream_ids: 123
+  actions: ["markAsRead"]
+  patterns: {}
+"""
+    yaml_file = tmp_path / "invalid_rules.yaml"
+    yaml_file.write_text(yaml_content)
+
+    # pydantic-yaml wraps parsing errors in ValidationError
+    with pytest.raises(ValidationError):
+        Rules.from_yaml(yaml_file)
+
+
+def test_rules_from_malformed_yaml(tmp_path: Path):
+    """Test loading Rules from malformed YAML raises an error (from yaml parser)."""
+    # This YAML is structurally invalid (bad indentation)
+    yaml_content = """
+- stream_ids: [feed/1]
+  actions: [markAsRead]
+  patterns:
+    title: [Test]
+ name: Unindented Name # Malformed YAML
+"""
+    yaml_file = tmp_path / "malformed_rules.yaml"
+    yaml_file.write_text(yaml_content)
+
+    # Expecting an error during YAML parsing
+    with pytest.raises(ParserError):
+        Rules.from_yaml(yaml_file)
+
+
+def test_rules_from_nonexistent_yaml():
+    """Test loading Rules from a non-existent file raises FileNotFoundError."""
+    non_existent_path = Path("non_existent_rules.yaml")
+    assert not non_existent_path.exists()  # Ensure it doesn't exist
+    with pytest.raises(FileNotFoundError):
+        Rules.from_yaml(non_existent_path)


### PR DESCRIPTION
- **Set up pytest**
- **Upgrade pydantic and pydantic-yaml**
- **Enable mypy check_untyped_defs**
- **Extract rule definitions into rules.py and add tests**
- **Ignore missing import**
- **Refactor RulesDict and Classifier**
- **Simplify merge_rules_dict implementation**
- **Simplify RulesDict.compile implementation**
- **Use defaultdict to simplify merge_rules_dict and compile**
- **Encapsulate pattern logic using PatternTexts class**
- **Flatten rule dictionary structure using tuple keys**
- **Remove RulesDictRoot type alias**
- **refactor(classifier): Make Classifier a RootModel of compiled rules**
- **refactor(classifier): Use __or__ operator for merging RulesDict instances**
- **refactor(classifier): Rename RulesDict to RulePatternIndex**
- **refactor(classifier): Make RulePatternIndex immutable**
- **refactor(classifier): Change Classifier to use BaseModel with a field**
- **fix(classifier): Correct iteration over rule patterns in from_rule**
- **fix(classifier): Correctly apply reduce in from_rules**
- **refactor(classifier): Make Classifier immutable**
- **feat(classifier): Add __bool__ method to PatternTexts**
- **fix(classifier): Improve reduce usage in from_rules**
- **fix(classifier): Provide initial value to reduce in from_yml**
- **refactor(classifier): Remove unnecessary __bool__ and redundant check**
- **refactor(classifier): Simplify and unify path handling in from_yml**
- **refactor(classifier): Use .get() instead of try-except in __to_act**
- **refactor(classifier): Simplify re.Pattern type hints**
- **feat(rules): Add validation to disallow empty PatternText**
- **refactor: Extract PatternText and PatternTexts into patterns module**
- **test(pattern_texts): Add test for compiling patterns containing pipe characters**
- **refactor(tests): Update EntryPatternTexts initialization in test_rules.py**
- **refactor(classifier): Add __init__ to RulePatternIndex for simpler empty instance creation**
- **feat(pattern_texts): Allow initializing PatternTexts with any Iterable**
- **refactor(classifier): Improve type hint and initialization in RulePatternIndex**
- **test(classifier): Add initial tests for RulePatternIndex**
- **refactor(classifier): Simplify RulePatternIndex.__or__ implementation**
- **test(classifier): Add tests for RulePatternIndex.__or__ operator**
- **test(classifier): Add unit tests for RulePatternIndex.from_rule**
- **refactor(tests): Consolidate RulePatternIndex.from_rule tests using parametrize**
- **test(classifier): Add unit tests for RulePatternIndex.from_rules**
- **test(classifier): Add basic initialization and immutability tests for Classifier**
- **test(classifier): Add unit tests for Classifier.from_rule_pattern_index**
- **feat(rules): Implement __or__ operator for merging Rules instances**
- **refactor(classifier): Make to_act public and add tests**
