### PR TITLE
rewrite feedly client

### DIFF
--- a/feedly_regexp_marker/__main__.py
+++ b/feedly_regexp_marker/__main__.py
@@ -6,7 +6,7 @@ from feedly.api_client.session import FileAuthStore
 from logzero import logger
 
 from feedly_regexp_marker.classifier import Classifier
-from feedly_regexp_marker.feedly_controller import FeedlyController
+from feedly_regexp_marker.feedly_client import FeedlyClient
 
 
 def cli(
@@ -17,22 +17,22 @@ def cli(
     dry_run: bool = False,
 ):
     try:
-        feedly_controller = FeedlyController(auth=FileAuthStore(token_dir=token_dir))
+        feedly_client = FeedlyClient(auth=FileAuthStore(token_dir=token_dir))
 
-        entries = feedly_controller.fetch_all_unread_entries()
+        entries = feedly_client.fetch_all_unread_entries()
         logger.info(f"fetched {len(entries)} entries.")
 
         clf = Classifier.from_yml(rules)
 
         entries_to_save = [entry for entry in entries if clf.to_save(entry)]
-        feedly_controller.save_entries(
+        feedly_client.save_entries(
             entries=entries_to_save,
             dry_run=dry_run,
         )
         logger.info(f"saved {len(entries_to_save)} entries.")
 
         entries_to_read = [entry for entry in entries if clf.to_read(entry)]
-        feedly_controller.read_entries(
+        feedly_client.read_entries(
             entries=entries_to_read,
             dry_run=dry_run,
         )

--- a/feedly_regexp_marker/__main__.py
+++ b/feedly_regexp_marker/__main__.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
-from feedly.api_client.session import FileAuthStore
+from feedly.api_client.session import FeedlySession, FileAuthStore
 from logzero import logger
 
 from feedly_regexp_marker.classifier import Classifier
@@ -17,7 +17,9 @@ def cli(
     dry_run: bool = False,
 ):
     try:
-        feedly_client = FeedlyClient(auth=FileAuthStore(token_dir=token_dir))
+        feedly_client = FeedlyClient(
+            session=FeedlySession(auth=FileAuthStore(token_dir=token_dir))
+        )
 
         entries = feedly_client.fetch_all_unread_entries()
         logger.info(f"fetched {len(entries)} entries.")

--- a/feedly_regexp_marker/__main__.py
+++ b/feedly_regexp_marker/__main__.py
@@ -21,7 +21,7 @@ def cli(
             session=FeedlySession(auth=FileAuthStore(token_dir=token_dir))
         )
 
-        entries = feedly_client.fetch_all_unread_entries()
+        entries = list(feedly_client.fetch_all_unread_entries())
         logger.info(f"fetched {len(entries)} entries.")
 
         clf = Classifier.from_yml(rules)

--- a/feedly_regexp_marker/classifier.py
+++ b/feedly_regexp_marker/classifier.py
@@ -10,7 +10,7 @@ from typing import Literal, Mapping, Optional, cast
 
 from pydantic import BaseModel, ConfigDict, RootModel
 
-from feedly_regexp_marker.feedly_controller import Action, Entry, StreamId
+from feedly_regexp_marker.feedly_client import Action, Entry, StreamId
 from feedly_regexp_marker.pattern_texts import PatternTexts
 from feedly_regexp_marker.rules import Rule, Rules
 

--- a/feedly_regexp_marker/feedly_client.py
+++ b/feedly_regexp_marker/feedly_client.py
@@ -44,7 +44,7 @@ class FeedlyClient:
     def __init__(self, auth: Auth) -> None:
         self.session = FeedlySession(auth=auth)
 
-    def _fetch_all_unread_entries(self, continuation: str | None) -> list[Entry]:
+    def fetch_unread_entries(self, continuation: str | None) -> list[Entry]:
         stream_contents = StreamContents(
             **self.session.do_api_request(
                 relative_url="/v3/streams/contents",
@@ -61,14 +61,14 @@ class FeedlyClient:
         )
 
         if stream_contents.continuation:
-            return stream_contents.items + self._fetch_all_unread_entries(
+            return stream_contents.items + self.fetch_unread_entries(
                 continuation=stream_contents.continuation
             )
         else:
             return stream_contents.items
 
     def fetch_all_unread_entries(self) -> list[Entry]:
-        return self._fetch_all_unread_entries(continuation=None)
+        return self.fetch_unread_entries(continuation=None)
 
     def __mark_entries(
         self, entries: list[Entry], action: Action, dry_run: bool

--- a/feedly_regexp_marker/feedly_client.py
+++ b/feedly_regexp_marker/feedly_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 
-from feedly.api_client.session import Auth, FeedlySession
+from feedly.api_client.session import FeedlySession
 from pydantic import BaseModel, ConfigDict
 
 StreamId = str
@@ -41,8 +41,8 @@ class StreamContents(BaseModel):
 
 
 class FeedlyClient:
-    def __init__(self, auth: Auth) -> None:
-        self.session = FeedlySession(auth=auth)
+    def __init__(self, session: FeedlySession) -> None:
+        self.session = session
 
     def fetch_unread_entries(self, continuation: str | None) -> list[Entry]:
         stream_contents = StreamContents.model_validate(

--- a/feedly_regexp_marker/feedly_client.py
+++ b/feedly_regexp_marker/feedly_client.py
@@ -45,8 +45,8 @@ class FeedlyClient:
         self.session = FeedlySession(auth=auth)
 
     def fetch_unread_entries(self, continuation: str | None) -> list[Entry]:
-        stream_contents = StreamContents(
-            **self.session.do_api_request(
+        stream_contents = StreamContents.model_validate(
+            self.session.do_api_request(
                 relative_url="/v3/streams/contents",
                 params=(
                     {

--- a/feedly_regexp_marker/feedly_client.py
+++ b/feedly_regexp_marker/feedly_client.py
@@ -48,7 +48,7 @@ class StreamContents(BaseModel):
         frozen = True
 
 
-class FeedlyController:
+class FeedlyClient:
     def __init__(self, auth: Auth) -> None:
         self.session = FeedlySession(auth=auth)
 

--- a/feedly_regexp_marker/feedly_client.py
+++ b/feedly_regexp_marker/feedly_client.py
@@ -70,9 +70,7 @@ class FeedlyClient:
     def fetch_all_unread_entries(self) -> list[Entry]:
         return self.fetch_unread_entries(continuation=None)
 
-    def __mark_entries(
-        self, entries: list[Entry], action: Action, dry_run: bool
-    ) -> None:
+    def mark_entries(self, entries: list[Entry], action: Action, dry_run: bool) -> None:
         if dry_run:
             print([entry.title for entry in entries])
             return
@@ -90,7 +88,7 @@ class FeedlyClient:
         )
 
     def save_entries(self, entries: list[Entry], dry_run: bool) -> None:
-        self.__mark_entries(entries=entries, action="markAsSaved", dry_run=dry_run)
+        self.mark_entries(entries=entries, action="markAsSaved", dry_run=dry_run)
 
     def read_entries(self, entries: list[Entry], dry_run: bool) -> None:
-        self.__mark_entries(entries=entries, action="markAsRead", dry_run=dry_run)
+        self.mark_entries(entries=entries, action="markAsRead", dry_run=dry_run)

--- a/feedly_regexp_marker/feedly_client.py
+++ b/feedly_regexp_marker/feedly_client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Generator, Literal, Optional
+from typing import Any, Generator, Iterable, Literal, Optional
 
 from feedly.api_client.session import FeedlySession
 from pydantic import BaseModel, ConfigDict
@@ -70,7 +70,9 @@ class FeedlyClient:
 
             continuation = stream_contents.continuation
 
-    def mark_entries(self, entries: list[Entry], action: Action, dry_run: bool) -> None:
+    def mark_entries(
+        self, entries: Iterable[Entry], action: Action, dry_run: bool
+    ) -> None:
         if dry_run:
             print([entry.title for entry in entries])
             return
@@ -87,8 +89,8 @@ class FeedlyClient:
             },
         )
 
-    def save_entries(self, entries: list[Entry], dry_run: bool) -> None:
+    def save_entries(self, entries: Iterable[Entry], dry_run: bool) -> None:
         self.mark_entries(entries=entries, action="markAsSaved", dry_run=dry_run)
 
-    def read_entries(self, entries: list[Entry], dry_run: bool) -> None:
+    def read_entries(self, entries: Iterable[Entry], dry_run: bool) -> None:
         self.mark_entries(entries=entries, action="markAsRead", dry_run=dry_run)

--- a/feedly_regexp_marker/feedly_client.py
+++ b/feedly_regexp_marker/feedly_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Literal, Optional
 
 from feedly.api_client.session import Auth, FeedlySession
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 StreamId = str
 EntryId = str
@@ -12,17 +12,13 @@ Action = Literal["markAsSaved", "markAsRead"]
 
 class EntryContent(BaseModel):
     content: str
-
-    class Config:
-        frozen = True
+    model_config = ConfigDict(frozen=True)
 
 
 class EntryOrigin(BaseModel):
     streamId: StreamId
     title: Optional[str] = None
-
-    class Config:
-        frozen = True
+    model_config = ConfigDict(frozen=True)
 
 
 class Entry(BaseModel):
@@ -33,9 +29,7 @@ class Entry(BaseModel):
     content: Optional[EntryContent] = None
     summary: Optional[EntryContent] = None
     origin: Optional[EntryOrigin] = None
-
-    class Config:
-        frozen = True
+    model_config = ConfigDict(frozen=True)
 
 
 class StreamContents(BaseModel):
@@ -43,9 +37,7 @@ class StreamContents(BaseModel):
 
     items: list[Entry]
     continuation: Optional[str] = None
-
-    class Config:
-        frozen = True
+    model_config = ConfigDict(frozen=True)
 
 
 class FeedlyClient:

--- a/feedly_regexp_marker/rules.py
+++ b/feedly_regexp_marker/rules.py
@@ -6,7 +6,7 @@ from typing import Optional
 from pydantic import BaseModel, ConfigDict, RootModel
 from pydantic_yaml import parse_yaml_file_as
 
-from feedly_regexp_marker.feedly_controller import Action, StreamId
+from feedly_regexp_marker.feedly_client import Action, StreamId
 from feedly_regexp_marker.pattern_texts import PatternTexts
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1149,6 +1149,23 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
@@ -1482,4 +1499,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "d96d2ca8d983fae1e5c4df3b48f4707a46a981647ecd7f31cb5047d5a66fa2b1"
+content-hash = "a3fd99d7949c85ed59fef344819b027bb9bcb20373e865183bcf33e4ef6e3477"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ isort = {extras = ["pyproject"], version = "^6.0.0"}
 mypy = "^1.14"
 pydocstyle = "^6.3.0"
 pytest = "^8.3.5"
+pytest-mock = "^3.14.0"
 
 [tool.poetry.scripts]
 feedly-regexp-marker = "feedly_regexp_marker.__main__:main"

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from feedly_regexp_marker.classifier import Classifier, EntryAttr, RulePatternIndex
-from feedly_regexp_marker.feedly_controller import Action, Entry, StreamId
+from feedly_regexp_marker.feedly_client import Action, Entry, StreamId
 from feedly_regexp_marker.pattern_texts import PatternTexts
 from feedly_regexp_marker.rules import EntryPatternTexts, Rule, Rules
 

--- a/tests/test_feedly_client.py
+++ b/tests/test_feedly_client.py
@@ -1,0 +1,228 @@
+from unittest.mock import MagicMock, call
+
+import pytest
+from feedly.api_client.session import FeedlySession
+from pytest_mock import MockerFixture
+
+from feedly_regexp_marker.feedly_client import Action, Entry, FeedlyClient
+
+# --- Test FeedlyClient ---
+
+
+@pytest.fixture
+def mock_session(mocker: MockerFixture) -> MagicMock:
+    """Fixture to return a mock of FeedlySession instance."""
+    # Specify spec=FeedlySession to mimic the interface
+    session_mock = mocker.MagicMock(spec=FeedlySession)
+    # Mock the user.id property
+    session_mock.user = mocker.MagicMock()
+    session_mock.user.id = "test_user_id_mocked"
+    return session_mock
+
+
+@pytest.fixture
+def feedly_client(mock_session: MagicMock) -> FeedlyClient:
+    """Fixture to create a FeedlyClient instance for testing."""
+    # Pass the mock session directly (DI)
+    return FeedlyClient(session=mock_session)
+
+
+class TestFeedlyClient:
+    def test_init(self, mock_session: MagicMock):
+        """Test FeedlyClient initialization sets the session correctly."""
+        client = FeedlyClient(session=mock_session)
+        assert client.session is mock_session
+
+    # --- Test fetch_all_unread_entries ---
+    def test_fetch_all_unread_entries_single_page(self, feedly_client: FeedlyClient):
+        """Test fetching when API returns all entries in one page."""
+        entry_data1 = {"id": "e1", "title": "Entry 1"}
+        entry_data2 = {"id": "e2", "title": "Entry 2"}
+        api_response = {
+            "items": [entry_data1, entry_data2],
+            "continuation": None,  # No continuation
+        }
+        # Set the API response
+        feedly_client.session.do_api_request.return_value = api_response
+
+        # Convert the generator to a list and verify the results
+        entries = list(feedly_client.fetch_all_unread_entries())
+
+        # Check API call parameters.
+        expected_params = {
+            "streamId": "user/test_user_id_mocked/category/global.all",
+            "count": "1000",
+            "ranked": "oldest",
+            "unreadOnly": "true",
+        }
+        feedly_client.session.do_api_request.assert_called_once_with(
+            relative_url="/v3/streams/contents", params=expected_params
+        )
+
+        # Check result (whether it has been converted to a Pydantic model).
+        assert len(entries) == 2
+        assert entries[0].id == "e1"
+        assert entries[1].id == "e2"
+        assert isinstance(entries[0], Entry)
+        assert isinstance(entries[1], Entry)
+
+    def test_fetch_all_unread_entries_multiple_pages(self, feedly_client: FeedlyClient):
+        """Test fetching handles pagination correctly via loop."""
+        entry_data1 = {"id": "e1"}
+        entry_data2 = {"id": "e2"}
+        entry_data3 = {"id": "e3"}
+
+        # Define responses for each API call
+        api_response_page1 = {
+            "items": [entry_data1, entry_data2],
+            "continuation": "cont1",
+        }
+        api_response_page2 = {"items": [entry_data3], "continuation": None}  # Last page
+
+        # Use side_effect to return different values for subsequent calls
+        feedly_client.session.do_api_request.side_effect = [
+            api_response_page1,
+            api_response_page2,
+        ]
+
+        # Convert the generator to a list and verify the results.
+        entries = list(feedly_client.fetch_all_unread_entries())
+
+        # Check API call parameters for both calls.
+        base_params = {
+            "streamId": "user/test_user_id_mocked/category/global.all",
+            "count": "1000",
+            "ranked": "oldest",
+            "unreadOnly": "true",
+        }
+        expected_calls = [
+            call(relative_url="/v3/streams/contents", params=base_params),  # First call
+            call(
+                relative_url="/v3/streams/contents",
+                params={**base_params, "continuation": "cont1"},
+            ),  # Second call
+        ]
+        feedly_client.session.do_api_request.assert_has_calls(expected_calls)
+        assert feedly_client.session.do_api_request.call_count == 2
+
+        # Check result (all items combined).
+        assert len(entries) == 3
+        assert entries[0].id == "e1"
+        assert entries[1].id == "e2"
+        assert entries[2].id == "e3"
+        assert all(isinstance(e, Entry) for e in entries)
+
+    def test_fetch_all_unread_entries_stops_on_empty_items(
+        self, feedly_client: FeedlyClient
+    ):
+        """Test fetching stops when API returns empty items even with continuation."""
+        entry_data1 = {"id": "e1"}
+        api_response_page1 = {"items": [entry_data1], "continuation": "cont1"}
+        api_response_page2 = {"items": [], "continuation": "cont2"}  # Empty items
+
+        feedly_client.session.do_api_request.side_effect = [
+            api_response_page1,
+            api_response_page2,
+        ]
+
+        entries = list(feedly_client.fetch_all_unread_entries())
+
+        # Check API calls (should only be two).
+        assert feedly_client.session.do_api_request.call_count == 2
+        # Check result (only items from the first page).
+        assert len(entries) == 1
+        assert entries[0].id == "e1"
+
+    def test_fetch_all_unread_entries_no_entries(self, feedly_client: FeedlyClient):
+        """Test fetch_all_unread_entries when API returns no entries initially."""
+        api_response: dict = {"items": [], "continuation": None}
+        feedly_client.session.do_api_request.return_value = api_response
+
+        entries = list(feedly_client.fetch_all_unread_entries())
+
+        feedly_client.session.do_api_request.assert_called_once()
+        assert entries == []
+
+    # --- Test mark_entries / save_entries / read_entries ---
+    def test_mark_entries_dry_run(
+        self, mocker: MockerFixture, feedly_client: FeedlyClient
+    ):
+        """Test mark_entries with dry_run=True prints titles and doesn't call the API."""
+        mock_print = mocker.patch("builtins.print")  # Mock the built-in print function.
+        entry1 = Entry(id="e1", title="Title 1")
+        entry2 = Entry(id="e2", title="Title 2")
+        # Also test passing a generator as input.
+        entries_to_mark_gen = (e for e in [entry1, entry2])
+
+        feedly_client.mark_entries(
+            entries=entries_to_mark_gen, action="markAsRead", dry_run=True
+        )
+        # Check API was NOT called
+        feedly_client.session.do_api_request.assert_not_called()
+        # Check print was called with the list of titles
+        # Note: The generator is consumed by the list comprehension inside mark_entries
+        mock_print.assert_called_once_with(["Title 1", "Title 2"])
+
+    def test_mark_entries_empty_iterable(self, feedly_client: FeedlyClient):
+        """Test mark_entries with an empty iterable doesn't call API."""
+        entries_to_mark: list[Entry] = []  # Empty list.
+        feedly_client.mark_entries(
+            entries=entries_to_mark, action="markAsRead", dry_run=False
+        )
+        feedly_client.session.do_api_request.assert_not_called()
+
+        feedly_client.mark_entries(
+            entries=entries_to_mark, action="markAsSaved", dry_run=False
+        )
+        feedly_client.session.do_api_request.assert_not_called()
+
+    @pytest.mark.parametrize("action_to_test", ["markAsRead", "markAsSaved"])
+    def test_mark_entries_api_call(
+        self, feedly_client: FeedlyClient, action_to_test: Action
+    ):
+        """Test mark_entries calls the correct API endpoint with correct data."""
+        entry1 = Entry(id="id_e1", title="Title 1")
+        entry2 = Entry(id="id_e2", title="Title 2")
+        # Pass the generator as input.
+        entries_to_mark_gen = (e for e in [entry1, entry2])
+
+        feedly_client.mark_entries(
+            entries=entries_to_mark_gen, action=action_to_test, dry_run=False
+        )
+
+        expected_data = {
+            "action": action_to_test,
+            "type": "entries",
+            "entryIds": ["id_e1", "id_e2"],  # List comprehension consumes the generator
+        }
+        feedly_client.session.do_api_request.assert_called_once_with(
+            relative_url="/v3/markers", data=expected_data
+        )
+
+    def test_save_entries_calls_mark(
+        self, mocker: MockerFixture, feedly_client: FeedlyClient
+    ):
+        """Test save_entries calls mark_entries with correct action."""
+        entry1 = Entry(id="e1")
+        entries = [entry1]
+        # Mock the mark_entries method.
+        mock_mark = mocker.patch.object(feedly_client, "mark_entries")
+        feedly_client.save_entries(entries=entries, dry_run=False)
+        # Check if it was called with action="markAsSaved"
+        mock_mark.assert_called_once_with(
+            entries=entries, action="markAsSaved", dry_run=False
+        )
+
+    def test_read_entries_calls_mark(
+        self, mocker: MockerFixture, feedly_client: FeedlyClient
+    ):
+        """Test read_entries calls mark_entries with correct action."""
+        entry1 = Entry(id="e1")
+        entries = [entry1]
+        # Mock the mark_entries method.
+        mock_mark = mocker.patch.object(feedly_client, "mark_entries")
+        feedly_client.read_entries(entries=entries, dry_run=False)
+        # Check if it was called with action="markAsRead"
+        mock_mark.assert_called_once_with(
+            entries=entries, action="markAsRead", dry_run=False
+        )


### PR DESCRIPTION
- **refactor: Rename FeedlyController to FeedlyClient**
- **refactor(feedly_client): Use Pydantic V2 model_config for model settings**
- **refactor(feedly_client): Make fetch_unread_entries public**
- **refactor(feedly_client): Make mark_entries public**
- **refactor(feedly_client): Use model_validate for StreamContents instantiation**
- **build(deps): Add pytest-mock dependency**
- **refactor(feedly_client): Inject FeedlySession dependency into FeedlyClient**
- **refactor(feedly_client): Improve entry fetching with loop and generator**
- **fix(main): Convert generator from fetch_all_unread_entries to list**
- **refactor(feedly_client): Accept Iterable[Entry] for marking methods**
- **test(feedly_client): Add unit tests for FeedlyClient**
